### PR TITLE
Add the ability to work with Web Proxy

### DIFF
--- a/src/main/java/com/microsoft/bingads/internal/HttpClientWebServiceCaller.java
+++ b/src/main/java/com/microsoft/bingads/internal/HttpClientWebServiceCaller.java
@@ -1,20 +1,26 @@
 package com.microsoft.bingads.internal;
 
 import java.io.IOException;
-import java.net.ProxySelector;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.List;
+import org.apache.cxf.common.util.StringUtils;
+import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.conn.params.ConnRoutePNames;
 import org.apache.http.impl.client.DefaultHttpClient;
-import org.apache.http.impl.conn.ProxySelectorRoutePlanner;
+import org.apache.http.params.BasicHttpParams;
+import org.apache.http.params.HttpConnectionParams;
+import org.apache.http.params.HttpParams;
 
 class HttpClientWebServiceCaller implements WebServiceCaller {
 
+	private static final int DEFAULT_TIMEOUT = 900 * 1000; // Set default read time out to 900 seconds or 15 minutes.
+	
 	@Override
     public HttpResponse post(URL requestUrl, List<NameValuePair> formValues) throws IOException {
         HttpClient client = null;
@@ -38,14 +44,42 @@ class HttpClientWebServiceCaller implements WebServiceCaller {
         }
 
     }
+
     
     private DefaultHttpClient createHttpClientWithProxy() {
-    	DefaultHttpClient client = new DefaultHttpClient();
 
-        ProxySelector proxySelector = ProxySelector.getDefault();
+    	try {
+    		String webProxyEnabled = System.getProperty("web.proxy.enabled");
+   	    	String proxyHost = System.getProperty("http.proxyHost");
+   	    	String proxyPortStr = System.getProperty("http.proxyPort");
+   			
+   			if (StringUtils.isEmpty(webProxyEnabled) || StringUtils.isEmpty(proxyHost) || StringUtils.isEmpty(proxyHost))
+   			{
+   				return new DefaultHttpClient();
+   			}
+   			
+   			String proxyMode = System.getProperty("http.proxyScheme");
+   			if (StringUtils.isEmpty(proxyMode))
+   			{
+   				proxyMode = HttpHost.DEFAULT_SCHEME_NAME;
+   			}
+   			
+   			int proxyPort = Integer.parseInt(proxyPortStr);
+   			
+   			HttpHost proxy = new HttpHost(proxyHost, proxyPort, proxyMode);
+   			final HttpParams httpParams = new BasicHttpParams();
+   			HttpConnectionParams.setConnectionTimeout(httpParams, DEFAULT_TIMEOUT);
+   			HttpConnectionParams.setSoTimeout(httpParams, DEFAULT_TIMEOUT);
+   			DefaultHttpClient baseHttpClient = new DefaultHttpClient(httpParams);
 
-        client.setRoutePlanner(new ProxySelectorRoutePlanner(client.getConnectionManager().getSchemeRegistry(), proxySelector));
-        
-        return client;
-    }
+   			// Set proxy server.
+   			baseHttpClient.getParams().setParameter(ConnRoutePNames.DEFAULT_PROXY, proxy);
+
+   			return baseHttpClient;
+   		}
+   		catch (Exception e) {
+   			String message = "Can't wrap client, exception: " + e.getMessage();
+   			throw new RuntimeException(message);
+   		}
+   	}
 }

--- a/src/main/java/com/microsoft/bingads/internal/HttpClientWebServiceCaller.java
+++ b/src/main/java/com/microsoft/bingads/internal/HttpClientWebServiceCaller.java
@@ -4,21 +4,29 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.List;
+import org.apache.cxf.common.util.StringUtils;
+import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.conn.params.ConnRoutePNames;
 import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.params.BasicHttpParams;
+import org.apache.http.params.HttpConnectionParams;
+import org.apache.http.params.HttpParams;
 
 class HttpClientWebServiceCaller implements WebServiceCaller {
 
-    @Override
+	private static final int DEFAULT_TIMEOUT = 900 * 1000; // Set default read time out to 900 seconds or 15 minutes.
+	
+	@Override
     public HttpResponse post(URL requestUrl, List<NameValuePair> formValues) throws IOException {
         HttpClient client = null;
 
         try {
-            client = new DefaultHttpClient();
+            client = createHttpClientWithProxy();
 
             final HttpPost httpPost = new HttpPost(requestUrl.toURI());
             
@@ -37,4 +45,41 @@ class HttpClientWebServiceCaller implements WebServiceCaller {
 
     }
 
+    
+    private DefaultHttpClient createHttpClientWithProxy() {
+
+    	try {
+    		String webProxyEnabled = System.getProperty("web.proxy.enabled");
+   	    	String proxyHost = System.getProperty("http.proxyHost");
+   	    	String proxyPortStr = System.getProperty("http.proxyPort");
+   			
+   			if (StringUtils.isEmpty(webProxyEnabled) || StringUtils.isEmpty(proxyHost) || StringUtils.isEmpty(proxyHost))
+   			{
+   				return new DefaultHttpClient();
+   			}
+   			
+   			String proxyMode = System.getProperty("http.proxyScheme");
+   			if (StringUtils.isEmpty(proxyMode))
+   			{
+   				proxyMode = HttpHost.DEFAULT_SCHEME_NAME;
+   			}
+   			
+   			int proxyPort = Integer.parseInt(proxyPortStr);
+   			
+   			HttpHost proxy = new HttpHost(proxyHost, proxyPort, proxyMode);
+   			final HttpParams httpParams = new BasicHttpParams();
+   			HttpConnectionParams.setConnectionTimeout(httpParams, DEFAULT_TIMEOUT);
+   			HttpConnectionParams.setSoTimeout(httpParams, DEFAULT_TIMEOUT);
+   			DefaultHttpClient baseHttpClient = new DefaultHttpClient(httpParams);
+
+   			// Set proxy server.
+   			baseHttpClient.getParams().setParameter(ConnRoutePNames.DEFAULT_PROXY, proxy);
+
+   			return baseHttpClient;
+   		}
+   		catch (Exception e) {
+   			String message = "Can't wrap client, exception: " + e.getMessage();
+   			throw new RuntimeException(message);
+   		}
+   	}
 }

--- a/src/main/java/com/microsoft/bingads/internal/HttpClientWebServiceCaller.java
+++ b/src/main/java/com/microsoft/bingads/internal/HttpClientWebServiceCaller.java
@@ -1,26 +1,20 @@
 package com.microsoft.bingads.internal;
 
 import java.io.IOException;
+import java.net.ProxySelector;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.List;
-import org.apache.cxf.common.util.StringUtils;
-import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpPost;
-import org.apache.http.conn.params.ConnRoutePNames;
 import org.apache.http.impl.client.DefaultHttpClient;
-import org.apache.http.params.BasicHttpParams;
-import org.apache.http.params.HttpConnectionParams;
-import org.apache.http.params.HttpParams;
+import org.apache.http.impl.conn.ProxySelectorRoutePlanner;
 
 class HttpClientWebServiceCaller implements WebServiceCaller {
 
-	private static final int DEFAULT_TIMEOUT = 900 * 1000; // Set default read time out to 900 seconds or 15 minutes.
-	
 	@Override
     public HttpResponse post(URL requestUrl, List<NameValuePair> formValues) throws IOException {
         HttpClient client = null;
@@ -44,42 +38,14 @@ class HttpClientWebServiceCaller implements WebServiceCaller {
         }
 
     }
-
     
     private DefaultHttpClient createHttpClientWithProxy() {
+    	DefaultHttpClient client = new DefaultHttpClient();
 
-    	try {
-    		String webProxyEnabled = System.getProperty("web.proxy.enabled");
-   	    	String proxyHost = System.getProperty("http.proxyHost");
-   	    	String proxyPortStr = System.getProperty("http.proxyPort");
-   			
-   			if (StringUtils.isEmpty(webProxyEnabled) || StringUtils.isEmpty(proxyHost) || StringUtils.isEmpty(proxyHost))
-   			{
-   				return new DefaultHttpClient();
-   			}
-   			
-   			String proxyMode = System.getProperty("http.proxyScheme");
-   			if (StringUtils.isEmpty(proxyMode))
-   			{
-   				proxyMode = HttpHost.DEFAULT_SCHEME_NAME;
-   			}
-   			
-   			int proxyPort = Integer.parseInt(proxyPortStr);
-   			
-   			HttpHost proxy = new HttpHost(proxyHost, proxyPort, proxyMode);
-   			final HttpParams httpParams = new BasicHttpParams();
-   			HttpConnectionParams.setConnectionTimeout(httpParams, DEFAULT_TIMEOUT);
-   			HttpConnectionParams.setSoTimeout(httpParams, DEFAULT_TIMEOUT);
-   			DefaultHttpClient baseHttpClient = new DefaultHttpClient(httpParams);
+        ProxySelector proxySelector = ProxySelector.getDefault();
 
-   			// Set proxy server.
-   			baseHttpClient.getParams().setParameter(ConnRoutePNames.DEFAULT_PROXY, proxy);
-
-   			return baseHttpClient;
-   		}
-   		catch (Exception e) {
-   			String message = "Can't wrap client, exception: " + e.getMessage();
-   			throw new RuntimeException(message);
-   		}
-   	}
+        client.setRoutePlanner(new ProxySelectorRoutePlanner(client.getConnectionManager().getSchemeRegistry(), proxySelector));
+        
+        return client;
+    }
 }

--- a/src/main/java/com/microsoft/bingads/internal/HttpClientWebServiceCaller.java
+++ b/src/main/java/com/microsoft/bingads/internal/HttpClientWebServiceCaller.java
@@ -1,26 +1,20 @@
 package com.microsoft.bingads.internal;
 
 import java.io.IOException;
+import java.net.ProxySelector;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.List;
-import org.apache.cxf.common.util.StringUtils;
-import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpPost;
-import org.apache.http.conn.params.ConnRoutePNames;
 import org.apache.http.impl.client.DefaultHttpClient;
-import org.apache.http.params.BasicHttpParams;
-import org.apache.http.params.HttpConnectionParams;
-import org.apache.http.params.HttpParams;
+import org.apache.http.impl.conn.ProxySelectorRoutePlanner;
 
 class HttpClientWebServiceCaller implements WebServiceCaller {
 
-	private static final int DEFAULT_TIMEOUT = 900 * 1000; // Set default read time out to 900 seconds or 15 minutes.
-	
 	@Override
     public HttpResponse post(URL requestUrl, List<NameValuePair> formValues) throws IOException {
         HttpClient client = null;
@@ -42,44 +36,16 @@ class HttpClientWebServiceCaller implements WebServiceCaller {
                 client.getConnectionManager().shutdown();
             }
         }
-
     }
 
     
-    private DefaultHttpClient createHttpClientWithProxy() {
+	 private DefaultHttpClient createHttpClientWithProxy() {
+    	DefaultHttpClient client = new DefaultHttpClient();
 
-    	try {
-    		String webProxyEnabled = System.getProperty("web.proxy.enabled");
-   	    	String proxyHost = System.getProperty("http.proxyHost");
-   	    	String proxyPortStr = System.getProperty("http.proxyPort");
-   			
-   			if (StringUtils.isEmpty(webProxyEnabled) || StringUtils.isEmpty(proxyHost) || StringUtils.isEmpty(proxyHost))
-   			{
-   				return new DefaultHttpClient();
-   			}
-   			
-   			String proxyMode = System.getProperty("http.proxyScheme");
-   			if (StringUtils.isEmpty(proxyMode))
-   			{
-   				proxyMode = HttpHost.DEFAULT_SCHEME_NAME;
-   			}
-   			
-   			int proxyPort = Integer.parseInt(proxyPortStr);
-   			
-   			HttpHost proxy = new HttpHost(proxyHost, proxyPort, proxyMode);
-   			final HttpParams httpParams = new BasicHttpParams();
-   			HttpConnectionParams.setConnectionTimeout(httpParams, DEFAULT_TIMEOUT);
-   			HttpConnectionParams.setSoTimeout(httpParams, DEFAULT_TIMEOUT);
-   			DefaultHttpClient baseHttpClient = new DefaultHttpClient(httpParams);
+        ProxySelector proxySelector = ProxySelector.getDefault();
 
-   			// Set proxy server.
-   			baseHttpClient.getParams().setParameter(ConnRoutePNames.DEFAULT_PROXY, proxy);
-
-   			return baseHttpClient;
-   		}
-   		catch (Exception e) {
-   			String message = "Can't wrap client, exception: " + e.getMessage();
-   			throw new RuntimeException(message);
-   		}
-   	}
+        client.setRoutePlanner(new ProxySelectorRoutePlanner(client.getConnectionManager().getSchemeRegistry(), proxySelector));
+        
+        return client;
+	 }
 }

--- a/src/main/java/com/microsoft/bingads/internal/utilities/HttpClientHttpFileService.java
+++ b/src/main/java/com/microsoft/bingads/internal/utilities/HttpClientHttpFileService.java
@@ -1,31 +1,37 @@
 package com.microsoft.bingads.internal.utilities;
 
+import com.microsoft.bingads.AsyncCallback;
+import com.microsoft.bingads.internal.ResultFuture;
+import com.microsoft.bingads.internal.functionalinterfaces.Consumer;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.ProxySelector;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.concurrent.Future;
+import org.apache.cxf.common.util.StringUtils;
+import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.conn.params.ConnRoutePNames;
 import org.apache.http.entity.mime.MultipartEntity;
 import org.apache.http.entity.mime.content.FileBody;
 import org.apache.http.impl.client.DefaultHttpClient;
-import org.apache.http.impl.conn.ProxySelectorRoutePlanner;
-import com.microsoft.bingads.AsyncCallback;
-import com.microsoft.bingads.internal.ResultFuture;
-import com.microsoft.bingads.internal.functionalinterfaces.Consumer;
+import org.apache.http.params.BasicHttpParams;
+import org.apache.http.params.HttpConnectionParams;
+import org.apache.http.params.HttpParams;
 
 public class HttpClientHttpFileService implements HttpFileService {
 	
+	private static final int DEFAULT_TIMEOUT = 900 * 1000; // Set default read time out to 900 seconds or 15 minutes.
+
     @Override
     public void downloadFile(String url, File tempZipFile, boolean overwrite) throws IOException, URISyntaxException {
         if (!overwrite && tempZipFile.exists()) {
@@ -145,15 +151,41 @@ public class HttpClientHttpFileService implements HttpFileService {
 
         return resultFuture;
     }
-
     
     private DefaultHttpClient createHttpClientWithProxy() {
-    	DefaultHttpClient client = new DefaultHttpClient();
+    	
+       	try {
+       		String webProxyEnabled = System.getProperty("web.proxy.enabled");
+   	    	String proxyHost = System.getProperty("http.proxyHost");
+   	    	String proxyPortStr = System.getProperty("http.proxyPort");
+   			
+   			if (StringUtils.isEmpty(webProxyEnabled) || StringUtils.isEmpty(proxyHost) || StringUtils.isEmpty(proxyHost))
+   			{
+   				return new DefaultHttpClient();
+   			}
+   			
+   			String proxyMode = System.getProperty("http.proxyScheme");
+   			if (StringUtils.isEmpty(proxyMode))
+   			{
+   				proxyMode = HttpHost.DEFAULT_SCHEME_NAME;
+   			}
+   			
+   			int proxyPort = Integer.parseInt(proxyPortStr);
+   			
+   			HttpHost proxy = new HttpHost(proxyHost, proxyPort, proxyMode);
+   			final HttpParams httpParams = new BasicHttpParams();
+   			HttpConnectionParams.setConnectionTimeout(httpParams, DEFAULT_TIMEOUT);
+   			HttpConnectionParams.setSoTimeout(httpParams, DEFAULT_TIMEOUT);
+   			DefaultHttpClient baseHttpClient = new DefaultHttpClient(httpParams);
 
-        ProxySelector proxySelector = ProxySelector.getDefault();
+   			// Set proxy server.
+   			baseHttpClient.getParams().setParameter(ConnRoutePNames.DEFAULT_PROXY, proxy);
 
-        client.setRoutePlanner(new ProxySelectorRoutePlanner(client.getConnectionManager().getSchemeRegistry(), proxySelector));
-        
-        return client;
-    }
+   			return baseHttpClient;
+   		}
+   		catch (Exception e) {
+   			String message = "Can't wrap client, exception: " + e.getMessage();
+   			throw new RuntimeException(message);
+   		}
+   	}
 }

--- a/src/main/java/com/microsoft/bingads/internal/utilities/HttpClientHttpFileService.java
+++ b/src/main/java/com/microsoft/bingads/internal/utilities/HttpClientHttpFileService.java
@@ -1,37 +1,31 @@
 package com.microsoft.bingads.internal.utilities;
 
-import com.microsoft.bingads.AsyncCallback;
-import com.microsoft.bingads.internal.ResultFuture;
-import com.microsoft.bingads.internal.functionalinterfaces.Consumer;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.ProxySelector;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.concurrent.Future;
-import org.apache.cxf.common.util.StringUtils;
-import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
-import org.apache.http.conn.params.ConnRoutePNames;
 import org.apache.http.entity.mime.MultipartEntity;
 import org.apache.http.entity.mime.content.FileBody;
 import org.apache.http.impl.client.DefaultHttpClient;
-import org.apache.http.params.BasicHttpParams;
-import org.apache.http.params.HttpConnectionParams;
-import org.apache.http.params.HttpParams;
+import org.apache.http.impl.conn.ProxySelectorRoutePlanner;
+import com.microsoft.bingads.AsyncCallback;
+import com.microsoft.bingads.internal.ResultFuture;
+import com.microsoft.bingads.internal.functionalinterfaces.Consumer;
 
 public class HttpClientHttpFileService implements HttpFileService {
 	
-	private static final int DEFAULT_TIMEOUT = 900 * 1000; // Set default read time out to 900 seconds or 15 minutes.
-
     @Override
     public void downloadFile(String url, File tempZipFile, boolean overwrite) throws IOException, URISyntaxException {
         if (!overwrite && tempZipFile.exists()) {
@@ -151,41 +145,15 @@ public class HttpClientHttpFileService implements HttpFileService {
 
         return resultFuture;
     }
+
     
     private DefaultHttpClient createHttpClientWithProxy() {
-    	
-       	try {
-       		String webProxyEnabled = System.getProperty("web.proxy.enabled");
-   	    	String proxyHost = System.getProperty("http.proxyHost");
-   	    	String proxyPortStr = System.getProperty("http.proxyPort");
-   			
-   			if (StringUtils.isEmpty(webProxyEnabled) || StringUtils.isEmpty(proxyHost) || StringUtils.isEmpty(proxyHost))
-   			{
-   				return new DefaultHttpClient();
-   			}
-   			
-   			String proxyMode = System.getProperty("http.proxyScheme");
-   			if (StringUtils.isEmpty(proxyMode))
-   			{
-   				proxyMode = HttpHost.DEFAULT_SCHEME_NAME;
-   			}
-   			
-   			int proxyPort = Integer.parseInt(proxyPortStr);
-   			
-   			HttpHost proxy = new HttpHost(proxyHost, proxyPort, proxyMode);
-   			final HttpParams httpParams = new BasicHttpParams();
-   			HttpConnectionParams.setConnectionTimeout(httpParams, DEFAULT_TIMEOUT);
-   			HttpConnectionParams.setSoTimeout(httpParams, DEFAULT_TIMEOUT);
-   			DefaultHttpClient baseHttpClient = new DefaultHttpClient(httpParams);
+    	DefaultHttpClient client = new DefaultHttpClient();
 
-   			// Set proxy server.
-   			baseHttpClient.getParams().setParameter(ConnRoutePNames.DEFAULT_PROXY, proxy);
+        ProxySelector proxySelector = ProxySelector.getDefault();
 
-   			return baseHttpClient;
-   		}
-   		catch (Exception e) {
-   			String message = "Can't wrap client, exception: " + e.getMessage();
-   			throw new RuntimeException(message);
-   		}
-   	}
+        client.setRoutePlanner(new ProxySelectorRoutePlanner(client.getConnectionManager().getSchemeRegistry(), proxySelector));
+        
+        return client;
+    }
 }

--- a/src/main/java/com/microsoft/bingads/internal/utilities/HttpClientHttpFileService.java
+++ b/src/main/java/com/microsoft/bingads/internal/utilities/HttpClientHttpFileService.java
@@ -12,18 +12,25 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.concurrent.Future;
-
+import org.apache.cxf.common.util.StringUtils;
+import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.conn.params.ConnRoutePNames;
 import org.apache.http.entity.mime.MultipartEntity;
 import org.apache.http.entity.mime.content.FileBody;
 import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.params.BasicHttpParams;
+import org.apache.http.params.HttpConnectionParams;
+import org.apache.http.params.HttpParams;
 
 public class HttpClientHttpFileService implements HttpFileService {
+	
+	private static final int DEFAULT_TIMEOUT = 900 * 1000; // Set default read time out to 900 seconds or 15 minutes.
 
     @Override
     public void downloadFile(String url, File tempZipFile, boolean overwrite) throws IOException, URISyntaxException {
@@ -34,7 +41,7 @@ public class HttpClientHttpFileService implements HttpFileService {
         HttpClient client = null;
 
         try {
-            client = new DefaultHttpClient();
+            client = createHttpClientWithProxy();
             HttpGet httpget = new HttpGet(new URI(url));
             HttpResponse response = client.execute(httpget);
             InputStream content = response.getEntity().getContent();
@@ -67,7 +74,7 @@ public class HttpClientHttpFileService implements HttpFileService {
             HttpClient client = null;
 
             try {
-                client = new DefaultHttpClient();
+                client = createHttpClientWithProxy();
                 HttpPost post = new HttpPost(uri);
                 addHeaders.accept(post);
 
@@ -113,7 +120,7 @@ public class HttpClientHttpFileService implements HttpFileService {
         HttpClient client = null;
 
         try {
-            client = new DefaultHttpClient();
+            client = createHttpClientWithProxy();
             HttpGet httpget = new HttpGet(new URI(url));
             HttpResponse response = client.execute(httpget);
             InputStream content = response.getEntity().getContent();
@@ -144,4 +151,41 @@ public class HttpClientHttpFileService implements HttpFileService {
 
         return resultFuture;
     }
+    
+    private DefaultHttpClient createHttpClientWithProxy() {
+    	
+       	try {
+       		String webProxyEnabled = System.getProperty("web.proxy.enabled");
+   	    	String proxyHost = System.getProperty("http.proxyHost");
+   	    	String proxyPortStr = System.getProperty("http.proxyPort");
+   			
+   			if (StringUtils.isEmpty(webProxyEnabled) || StringUtils.isEmpty(proxyHost) || StringUtils.isEmpty(proxyHost))
+   			{
+   				return new DefaultHttpClient();
+   			}
+   			
+   			String proxyMode = System.getProperty("http.proxyScheme");
+   			if (StringUtils.isEmpty(proxyMode))
+   			{
+   				proxyMode = HttpHost.DEFAULT_SCHEME_NAME;
+   			}
+   			
+   			int proxyPort = Integer.parseInt(proxyPortStr);
+   			
+   			HttpHost proxy = new HttpHost(proxyHost, proxyPort, proxyMode);
+   			final HttpParams httpParams = new BasicHttpParams();
+   			HttpConnectionParams.setConnectionTimeout(httpParams, DEFAULT_TIMEOUT);
+   			HttpConnectionParams.setSoTimeout(httpParams, DEFAULT_TIMEOUT);
+   			DefaultHttpClient baseHttpClient = new DefaultHttpClient(httpParams);
+
+   			// Set proxy server.
+   			baseHttpClient.getParams().setParameter(ConnRoutePNames.DEFAULT_PROXY, proxy);
+
+   			return baseHttpClient;
+   		}
+   		catch (Exception e) {
+   			String message = "Can't wrap client, exception: " + e.getMessage();
+   			throw new RuntimeException(message);
+   		}
+   	}
 }


### PR DESCRIPTION
To Work with Bing Ads API behind a Web Proxy need to defined the
following system properties:
1 - web.proxy.enabled
2 - http.proxyHost
3 - http.proxyPort

if one of these properties is null the SDK continue to work without Web
Proxy

Example java code:
System.setProperty("web.proxy.enabled", "true");
System.setProperty("https.proxyHost", “127.0.0.1”);
System.setProperty("https.proxyPort", “3128”);