### PR TITLE
Support setting API environment as a parameter on BulkServiceManager.

### DIFF
--- a/src/main/java/com/microsoft/bingads/v10/bulk/BulkDownloadOperation.java
+++ b/src/main/java/com/microsoft/bingads/v10/bulk/BulkDownloadOperation.java
@@ -1,5 +1,6 @@
 package com.microsoft.bingads.v10.bulk;
 
+import com.microsoft.bingads.ApiEnvironment;
 import com.microsoft.bingads.AuthorizationData;
 import com.microsoft.bingads.v10.internal.bulk.DownloadStatusProvider;
 
@@ -36,8 +37,16 @@ public class BulkDownloadOperation extends BulkOperation<DownloadStatus> {
         super(requestId, authorizationData, new DownloadStatusProvider(requestId, authorizationData));
     }
 
+    public BulkDownloadOperation(String requestId, AuthorizationData authorizationData, ApiEnvironment apiEnvironment) {
+        super(requestId, authorizationData, new DownloadStatusProvider(requestId, authorizationData), null, apiEnvironment);
+    }
+
     BulkDownloadOperation(String requestId, AuthorizationData authorizationData, String trackingId) {
         super(requestId, authorizationData, new DownloadStatusProvider(requestId, authorizationData), trackingId);
+    }
+
+    BulkDownloadOperation(String requestId, AuthorizationData authorizationData, String trackingId, ApiEnvironment apiEnvironment) {
+        super(requestId, authorizationData, new DownloadStatusProvider(requestId, authorizationData), trackingId, apiEnvironment);
     }
     
     @Override

--- a/src/main/java/com/microsoft/bingads/v10/bulk/BulkOperation.java
+++ b/src/main/java/com/microsoft/bingads/v10/bulk/BulkOperation.java
@@ -1,5 +1,6 @@
 package com.microsoft.bingads.v10.bulk;
 
+import com.microsoft.bingads.ApiEnvironment;
 import com.microsoft.bingads.AsyncCallback;
 import com.microsoft.bingads.AuthorizationData;
 import com.microsoft.bingads.internal.ParentCallback;
@@ -57,14 +58,22 @@ public abstract class BulkOperation<TStatus> {
     private BulkOperationStatus<TStatus> finalStatus;
 
     BulkOperation(String requestId, AuthorizationData authorizationData) {
-        this(requestId, authorizationData, null, null);
+        this(requestId, authorizationData, null, null, null);
+    }
+
+    BulkOperation(String requestId, AuthorizationData authorizationData, ApiEnvironment apiEnvironment) {
+        this(requestId, authorizationData, null, null, apiEnvironment);
     }
 
     BulkOperation(String requestId, AuthorizationData authorizationData, BulkOperationStatusProvider<TStatus> statusProvider) {
-        this(requestId, authorizationData, statusProvider, null);
+        this(requestId, authorizationData, statusProvider, null, null);
     }
 
     BulkOperation(String requestId, AuthorizationData authorizationData, BulkOperationStatusProvider<TStatus> statusProvider, String trackingId) {
+        this(requestId, authorizationData, statusProvider, trackingId, null);
+    }
+
+    BulkOperation(String requestId, AuthorizationData authorizationData, BulkOperationStatusProvider<TStatus> statusProvider, String trackingId, ApiEnvironment apiEnvironment) {
         this.statusProvider = statusProvider;
         this.requestId = requestId;
         this.authorizationData = authorizationData;
@@ -72,7 +81,7 @@ public abstract class BulkOperation<TStatus> {
 
         statusPollIntervalInMilliseconds = Config.DEFAULT_STATUS_CHECK_INTERVAL_IN_MS;
 
-        this.serviceClient = new ServiceClient<IBulkService>(authorizationData, IBulkService.class);
+        this.serviceClient = new ServiceClient<IBulkService>(authorizationData, apiEnvironment, IBulkService.class);
 
         zipExtractor = new SimpleZipExtractor();
 

--- a/src/main/java/com/microsoft/bingads/v10/bulk/BulkServiceManager.java
+++ b/src/main/java/com/microsoft/bingads/v10/bulk/BulkServiceManager.java
@@ -1,5 +1,6 @@
 package com.microsoft.bingads.v10.bulk;
 
+import com.microsoft.bingads.ApiEnvironment;
 import com.microsoft.bingads.AsyncCallback;
 import com.microsoft.bingads.Authentication;
 import com.microsoft.bingads.AuthorizationData;
@@ -65,6 +66,7 @@ public class BulkServiceManager {
     private HttpFileService httpFileService;
     private ZipExtractor zipExtractor;
     private BulkFileReaderFactory bulkFileReaderFactory;
+    private ApiEnvironment apiEnvironment;
 
     private int statusPollIntervalInMilliseconds;
 
@@ -78,18 +80,23 @@ public class BulkServiceManager {
      * @param authorizationData Represents a user who intends to access the corresponding customer and account.
      */
     public BulkServiceManager(AuthorizationData authorizationData) {
-        this(authorizationData, new HttpClientHttpFileService(), new SimpleZipExtractor(), new CSVBulkFileReaderFactory());
+        this(authorizationData, null);
+    }
+
+    public BulkServiceManager(AuthorizationData authorizationData, ApiEnvironment apiEnvironment) {
+        this(authorizationData, new HttpClientHttpFileService(), new SimpleZipExtractor(), new CSVBulkFileReaderFactory(), apiEnvironment);
     }
 
     private BulkServiceManager(AuthorizationData authorizationData,
             HttpFileService httpFileService, ZipExtractor zipExtractor,
-            BulkFileReaderFactory bulkFileReaderFactory) {
+            BulkFileReaderFactory bulkFileReaderFactory, ApiEnvironment apiEnvironment) {
         this.authorizationData = authorizationData;
         this.httpFileService = httpFileService;
         this.zipExtractor = zipExtractor;
         this.bulkFileReaderFactory = bulkFileReaderFactory;
+        this.apiEnvironment = apiEnvironment;
 
-        serviceClient = new ServiceClient<IBulkService>(this.authorizationData, IBulkService.class);
+        serviceClient = new ServiceClient<IBulkService>(this.authorizationData, apiEnvironment, IBulkService.class);
 
         workingDirectory = new File(System.getProperty("java.io.tmpdir"), "BingAdsSDK");
 
@@ -395,7 +402,7 @@ public class BulkServiceManager {
 
                         String trackingId = ServiceUtils.GetTrackingId(res);
 
-                        BulkDownloadOperation operation = new BulkDownloadOperation(response.getDownloadRequestId(), authorizationData, trackingId);
+                        BulkDownloadOperation operation = new BulkDownloadOperation(response.getDownloadRequestId(), authorizationData, trackingId, apiEnvironment);
 
                         operation.setStatusPollIntervalInMilliseconds(statusPollIntervalInMilliseconds);
 
@@ -420,7 +427,7 @@ public class BulkServiceManager {
 
                         response = res.get();
 
-                        BulkDownloadOperation operation = new BulkDownloadOperation(response.getDownloadRequestId(), authorizationData, ServiceUtils.GetTrackingId(res));
+                        BulkDownloadOperation operation = new BulkDownloadOperation(response.getDownloadRequestId(), authorizationData, ServiceUtils.GetTrackingId(res), apiEnvironment);
 
                         operation.setStatusPollIntervalInMilliseconds(statusPollIntervalInMilliseconds);
 
@@ -504,7 +511,7 @@ public class BulkServiceManager {
                         compressedFilePath.delete();
                     }
 
-                    BulkUploadOperation operation = new BulkUploadOperation(response.getRequestId(), authorizationData, service, trackingId);
+                    BulkUploadOperation operation = new BulkUploadOperation(response.getRequestId(), authorizationData, service, trackingId, apiEnvironment);
 
                     operation.setStatusPollIntervalInMilliseconds(statusPollIntervalInMilliseconds);
 

--- a/src/main/java/com/microsoft/bingads/v10/bulk/BulkUploadOperation.java
+++ b/src/main/java/com/microsoft/bingads/v10/bulk/BulkUploadOperation.java
@@ -1,5 +1,6 @@
 package com.microsoft.bingads.v10.bulk;
 
+import com.microsoft.bingads.ApiEnvironment;
 import com.microsoft.bingads.AuthorizationData;
 import com.microsoft.bingads.v10.internal.bulk.UploadStatusProvider;
 
@@ -28,11 +29,19 @@ public class BulkUploadOperation extends BulkOperation<UploadStatus> {
      * @param authorizationData Represents a user who intends to access the corresponding customer and account.
      */
     public BulkUploadOperation(String requestId, AuthorizationData authorizationData, IBulkService service) {
-        this(requestId, authorizationData, service, null);
+        this(requestId, authorizationData, service, null, null);
+    }
+
+    public BulkUploadOperation(String requestId, AuthorizationData authorizationData, IBulkService service, ApiEnvironment apiEnvironment) {
+        this(requestId, authorizationData, service, null, apiEnvironment);
     }
 
     protected BulkUploadOperation(String requestId, AuthorizationData authorizationData, IBulkService service, String trackingId) {
-        super(requestId, authorizationData, new UploadStatusProvider(requestId), trackingId);
+        this(requestId, authorizationData, service, trackingId, null);
+    }
+
+    protected BulkUploadOperation(String requestId, AuthorizationData authorizationData, IBulkService service, String trackingId, ApiEnvironment apiEnvironment) {
+        super(requestId, authorizationData, new UploadStatusProvider(requestId), trackingId, apiEnvironment);
     }
 
     @Override


### PR DESCRIPTION
It is very inconvenient for us to use bingads.properties to switch between sandbox and production environments.  We are developing a grails project which has configurations for 3 different environments (development, test, and production). Grails allows us to easily specify configuration values per environment in a single file. When we run our project, all we have to do is specify the environment we're using on the command line, and all of the configuration settings for that environment automatically take effect. bingads.properties forces us to do things differently just for bing--we can't have our configuration settings for all environments in one file. Instead, we have to somehow get the correct bingads.properties file in place. It's just not convenient for us, and it's the only 3rd party library of many that we're using that is forcing us to do something like this.

ServiceClient already has support for specifying the ApiEnvironment to use, which is great. However, BulkServiceManager doesn't appear to support specifying the ApiEnvironment, so using bingads.properties is the only way to use the sandbox environment with BulkServiceManager. My changes allow setting the ApiEnvironment to use for bulk uploads and downloads with BulkServiceManager. The changes should be backwards compatible, as I've only added additional methods that support the extra ApiEnvironment parameter.