### PR TITLE
equals(Object obj)" and "hashCode()" should be overridden in pairs

### DIFF
--- a/src/main/java/com/microsoft/bingads/internal/OAuthRequestParameters.java
+++ b/src/main/java/com/microsoft/bingads/internal/OAuthRequestParameters.java
@@ -87,6 +87,17 @@ class OAuthRequestParameters {
         return true;
     }
 
+    @Override
+    public int hashCode() {
+        int result = this.clientId != null ? this.clientId.hashCode() : 0;
+        result = 31 * result + (this.clientSecret != null ? this.clientSecret.hashCode() : 0);
+        result = 31 * result + (this.redirectionUri != null ? this.redirectionUri.hashCode() : 0);
+        result = 31 * result + (this.grantType != null ? this.grantType.hashCode() : 0);
+        result = 31 * result + (this.grantParamName != null ? this.grantParamName.hashCode() : 0);
+        result = 31 * result + (this.grantValue != null ? this.grantValue.hashCode() : 0);
+        return result;
+    }
+
     public String getClientId() {
         return clientId;
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1206 - “equals(Object obj)" and "hashCode()" should be overridden in pairs ”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1206
Please let me know if you have any questions.
Ayman Abdelghany.