### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/proxies/com/microsoft/bingads/bulk/BulkDownloadEntityConverter.java
+++ b/proxies/com/microsoft/bingads/bulk/BulkDownloadEntityConverter.java
@@ -8,6 +8,9 @@ import java.util.Collection;
  */
 public class BulkDownloadEntityConverter {
 
+    private BulkDownloadEntityConverter() {
+    }
+
     public static Collection<BulkDownloadEntity> convertToList(String enums) {
         String[] values = enums.split(" ");
 

--- a/proxies/com/microsoft/bingads/bulk/DataScopeConverter.java
+++ b/proxies/com/microsoft/bingads/bulk/DataScopeConverter.java
@@ -8,6 +8,9 @@ import java.util.Collection;
  */
 public class DataScopeConverter {
 
+    private DataScopeConverter() {
+    }
+
     public static Collection<DataScope> convertToList(String enums) {
         String[] values = enums.split(" ");
 

--- a/proxies/com/microsoft/bingads/campaignmanagement/AdDistributionConverter.java
+++ b/proxies/com/microsoft/bingads/campaignmanagement/AdDistributionConverter.java
@@ -8,6 +8,9 @@ import java.util.Collection;
  */
 public class AdDistributionConverter {
 
+    private AdDistributionConverter() {
+    }
+
     public static Collection<AdDistribution> convertToList(String enums) {
         String[] values = enums.split(" ");
 

--- a/proxies/com/microsoft/bingads/campaignmanagement/AdExtensionsTypeFilterConverter.java
+++ b/proxies/com/microsoft/bingads/campaignmanagement/AdExtensionsTypeFilterConverter.java
@@ -8,6 +8,9 @@ import java.util.Collection;
  */
 public class AdExtensionsTypeFilterConverter {
 
+    private AdExtensionsTypeFilterConverter() {
+    }
+
     public static Collection<AdExtensionsTypeFilter> convertToList(String enums) {
         String[] values = enums.split(" ");
 

--- a/proxies/com/microsoft/bingads/campaignmanagement/CampaignCriterionTypeConverter.java
+++ b/proxies/com/microsoft/bingads/campaignmanagement/CampaignCriterionTypeConverter.java
@@ -8,6 +8,9 @@ import java.util.Collection;
  */
 public class CampaignCriterionTypeConverter {
 
+    private CampaignCriterionTypeConverter() {
+    }
+
     public static Collection<CampaignCriterionType> convertToList(String enums) {
         String[] values = enums.split(" ");
 

--- a/proxies/com/microsoft/bingads/campaignmanagement/CampaignTypeConverter.java
+++ b/proxies/com/microsoft/bingads/campaignmanagement/CampaignTypeConverter.java
@@ -8,6 +8,9 @@ import java.util.Collection;
  */
 public class CampaignTypeConverter {
 
+    private CampaignTypeConverter() {
+    }
+
     public static Collection<CampaignType> convertToList(String enums) {
         String[] values = enums.split(" ");
 

--- a/proxies/com/microsoft/bingads/campaignmanagement/CriterionTypeConverter.java
+++ b/proxies/com/microsoft/bingads/campaignmanagement/CriterionTypeConverter.java
@@ -8,6 +8,9 @@ import java.util.Collection;
  */
 public class CriterionTypeConverter {
 
+    private CriterionTypeConverter() {
+    }
+
     public static Collection<CriterionType> convertToList(String enums) {
         String[] values = enums.split(" ");
 

--- a/proxies/com/microsoft/bingads/campaignmanagement/MediaEnabledEntityFilterConverter.java
+++ b/proxies/com/microsoft/bingads/campaignmanagement/MediaEnabledEntityFilterConverter.java
@@ -8,6 +8,9 @@ import java.util.Collection;
  */
 public class MediaEnabledEntityFilterConverter {
 
+    private MediaEnabledEntityFilterConverter() {
+    }
+
     public static Collection<MediaEnabledEntityFilter> convertToList(String enums) {
         String[] values = enums.split(" ");
 

--- a/proxies/com/microsoft/bingads/optimizer/BidOpportunityTypeConverter.java
+++ b/proxies/com/microsoft/bingads/optimizer/BidOpportunityTypeConverter.java
@@ -8,6 +8,9 @@ import java.util.Collection;
  */
 public class BidOpportunityTypeConverter {
 
+    private BidOpportunityTypeConverter() {
+    }
+
     public static Collection<BidOpportunityType> convertToList(String enums) {
         String[] values = enums.split(" ");
 

--- a/proxies/com/microsoft/bingads/optimizer/KeywordOpportunityTypeConverter.java
+++ b/proxies/com/microsoft/bingads/optimizer/KeywordOpportunityTypeConverter.java
@@ -8,6 +8,9 @@ import java.util.Collection;
  */
 public class KeywordOpportunityTypeConverter {
 
+    private KeywordOpportunityTypeConverter() {
+    }
+
     public static Collection<KeywordOpportunityType> convertToList(String enums) {
         String[] values = enums.split(" ");
 

--- a/proxies/com/microsoft/bingads/reporting/AdDistributionReportFilterConverter.java
+++ b/proxies/com/microsoft/bingads/reporting/AdDistributionReportFilterConverter.java
@@ -8,6 +8,9 @@ import java.util.Collection;
  */
 public class AdDistributionReportFilterConverter {
 
+    private AdDistributionReportFilterConverter() {
+    }
+
     public static Collection<AdDistributionReportFilter> convertToList(String enums) {
         String[] values = enums.split(" ");
 

--- a/proxies/com/microsoft/bingads/reporting/AdGroupStatusReportFilterConverter.java
+++ b/proxies/com/microsoft/bingads/reporting/AdGroupStatusReportFilterConverter.java
@@ -8,6 +8,9 @@ import java.util.Collection;
  */
 public class AdGroupStatusReportFilterConverter {
 
+    private AdGroupStatusReportFilterConverter() {
+    }
+
     public static Collection<AdGroupStatusReportFilter> convertToList(String enums) {
         String[] values = enums.split(" ");
 

--- a/proxies/com/microsoft/bingads/reporting/AdStatusReportFilterConverter.java
+++ b/proxies/com/microsoft/bingads/reporting/AdStatusReportFilterConverter.java
@@ -8,6 +8,9 @@ import java.util.Collection;
  */
 public class AdStatusReportFilterConverter {
 
+    private AdStatusReportFilterConverter() {
+    }
+
     public static Collection<AdStatusReportFilter> convertToList(String enums) {
         String[] values = enums.split(" ");
 

--- a/proxies/com/microsoft/bingads/reporting/AdTypeReportFilterConverter.java
+++ b/proxies/com/microsoft/bingads/reporting/AdTypeReportFilterConverter.java
@@ -8,6 +8,9 @@ import java.util.Collection;
  */
 public class AdTypeReportFilterConverter {
 
+    private AdTypeReportFilterConverter() {
+    }
+
     public static Collection<AdTypeReportFilter> convertToList(String enums) {
         String[] values = enums.split(" ");
 

--- a/proxies/com/microsoft/bingads/reporting/BidMatchTypeReportFilterConverter.java
+++ b/proxies/com/microsoft/bingads/reporting/BidMatchTypeReportFilterConverter.java
@@ -8,6 +8,9 @@ import java.util.Collection;
  */
 public class BidMatchTypeReportFilterConverter {
 
+    private BidMatchTypeReportFilterConverter() {
+    }
+
     public static Collection<BidMatchTypeReportFilter> convertToList(String enums) {
         String[] values = enums.split(" ");
 

--- a/proxies/com/microsoft/bingads/reporting/CampaignStatusReportFilterConverter.java
+++ b/proxies/com/microsoft/bingads/reporting/CampaignStatusReportFilterConverter.java
@@ -8,6 +8,9 @@ import java.util.Collection;
  */
 public class CampaignStatusReportFilterConverter {
 
+    private CampaignStatusReportFilterConverter() {
+    }
+
     public static Collection<CampaignStatusReportFilter> convertToList(String enums) {
         String[] values = enums.split(" ");
 

--- a/proxies/com/microsoft/bingads/reporting/ChangeEntityReportFilterConverter.java
+++ b/proxies/com/microsoft/bingads/reporting/ChangeEntityReportFilterConverter.java
@@ -8,6 +8,9 @@ import java.util.Collection;
  */
 public class ChangeEntityReportFilterConverter {
 
+    private ChangeEntityReportFilterConverter() {
+    }
+
     public static Collection<ChangeEntityReportFilter> convertToList(String enums) {
         String[] values = enums.split(" ");
 

--- a/proxies/com/microsoft/bingads/reporting/ChangeTypeReportFilterConverter.java
+++ b/proxies/com/microsoft/bingads/reporting/ChangeTypeReportFilterConverter.java
@@ -8,6 +8,9 @@ import java.util.Collection;
  */
 public class ChangeTypeReportFilterConverter {
 
+    private ChangeTypeReportFilterConverter() {
+    }
+
     public static Collection<ChangeTypeReportFilter> convertToList(String enums) {
         String[] values = enums.split(" ");
 

--- a/proxies/com/microsoft/bingads/reporting/ComponentTypeFilterConverter.java
+++ b/proxies/com/microsoft/bingads/reporting/ComponentTypeFilterConverter.java
@@ -8,6 +8,9 @@ import java.util.Collection;
  */
 public class ComponentTypeFilterConverter {
 
+    private ComponentTypeFilterConverter() {
+    }
+
     public static Collection<ComponentTypeFilter> convertToList(String enums) {
         String[] values = enums.split(" ");
 

--- a/proxies/com/microsoft/bingads/reporting/DeliveredMatchTypeReportFilterConverter.java
+++ b/proxies/com/microsoft/bingads/reporting/DeliveredMatchTypeReportFilterConverter.java
@@ -8,6 +8,9 @@ import java.util.Collection;
  */
 public class DeliveredMatchTypeReportFilterConverter {
 
+    private DeliveredMatchTypeReportFilterConverter() {
+    }
+
     public static Collection<DeliveredMatchTypeReportFilter> convertToList(String enums) {
         String[] values = enums.split(" ");
 

--- a/proxies/com/microsoft/bingads/reporting/DeviceOSReportFilterConverter.java
+++ b/proxies/com/microsoft/bingads/reporting/DeviceOSReportFilterConverter.java
@@ -8,6 +8,9 @@ import java.util.Collection;
  */
 public class DeviceOSReportFilterConverter {
 
+    private DeviceOSReportFilterConverter() {
+    }
+
     public static Collection<DeviceOSReportFilter> convertToList(String enums) {
         String[] values = enums.split(" ");
 

--- a/proxies/com/microsoft/bingads/reporting/DeviceTypeReportFilterConverter.java
+++ b/proxies/com/microsoft/bingads/reporting/DeviceTypeReportFilterConverter.java
@@ -8,6 +8,9 @@ import java.util.Collection;
  */
 public class DeviceTypeReportFilterConverter {
 
+    private DeviceTypeReportFilterConverter() {
+    }
+
     public static Collection<DeviceTypeReportFilter> convertToList(String enums) {
         String[] values = enums.split(" ");
 

--- a/proxies/com/microsoft/bingads/reporting/PricingModelReportFilterConverter.java
+++ b/proxies/com/microsoft/bingads/reporting/PricingModelReportFilterConverter.java
@@ -8,6 +8,9 @@ import java.util.Collection;
  */
 public class PricingModelReportFilterConverter {
 
+    private PricingModelReportFilterConverter() {
+    }
+
     public static Collection<PricingModelReportFilter> convertToList(String enums) {
         String[] values = enums.split(" ");
 

--- a/proxies/com/microsoft/bingads/reporting/RichAdSubTypeFilterConverter.java
+++ b/proxies/com/microsoft/bingads/reporting/RichAdSubTypeFilterConverter.java
@@ -8,6 +8,9 @@ import java.util.Collection;
  */
 public class RichAdSubTypeFilterConverter {
 
+    private RichAdSubTypeFilterConverter() {
+    }
+
     public static Collection<RichAdSubTypeFilter> convertToList(String enums) {
         String[] values = enums.split(" ");
 

--- a/proxies/com/microsoft/bingads/v10/adinsight/BidOpportunityTypeConverter.java
+++ b/proxies/com/microsoft/bingads/v10/adinsight/BidOpportunityTypeConverter.java
@@ -8,6 +8,9 @@ import java.util.Collection;
  */
 public class BidOpportunityTypeConverter {
 
+    private BidOpportunityTypeConverter() {
+    }
+
     public static Collection<BidOpportunityType> convertToList(String enums) {
         String[] values = enums.split(" ");
 

--- a/proxies/com/microsoft/bingads/v10/adinsight/KeywordOpportunityTypeConverter.java
+++ b/proxies/com/microsoft/bingads/v10/adinsight/KeywordOpportunityTypeConverter.java
@@ -8,6 +8,9 @@ import java.util.Collection;
  */
 public class KeywordOpportunityTypeConverter {
 
+    private KeywordOpportunityTypeConverter() {
+    }
+
     public static Collection<KeywordOpportunityType> convertToList(String enums) {
         String[] values = enums.split(" ");
 

--- a/proxies/com/microsoft/bingads/v10/bulk/BulkDownloadEntityConverter.java
+++ b/proxies/com/microsoft/bingads/v10/bulk/BulkDownloadEntityConverter.java
@@ -8,6 +8,9 @@ import java.util.Collection;
  */
 public class BulkDownloadEntityConverter {
 
+    private BulkDownloadEntityConverter() {
+    }
+
     public static Collection<BulkDownloadEntity> convertToList(String enums) {
         String[] values = enums.split(" ");
 

--- a/proxies/com/microsoft/bingads/v10/bulk/DataScopeConverter.java
+++ b/proxies/com/microsoft/bingads/v10/bulk/DataScopeConverter.java
@@ -8,6 +8,9 @@ import java.util.Collection;
  */
 public class DataScopeConverter {
 
+    private DataScopeConverter() {
+    }
+
     public static Collection<DataScope> convertToList(String enums) {
         String[] values = enums.split(" ");
 

--- a/proxies/com/microsoft/bingads/v10/campaignmanagement/AdDistributionConverter.java
+++ b/proxies/com/microsoft/bingads/v10/campaignmanagement/AdDistributionConverter.java
@@ -8,6 +8,9 @@ import java.util.Collection;
  */
 public class AdDistributionConverter {
 
+    private AdDistributionConverter() {
+    }
+
     public static Collection<AdDistribution> convertToList(String enums) {
         String[] values = enums.split(" ");
 

--- a/proxies/com/microsoft/bingads/v10/campaignmanagement/AdExtensionsTypeFilterConverter.java
+++ b/proxies/com/microsoft/bingads/v10/campaignmanagement/AdExtensionsTypeFilterConverter.java
@@ -8,6 +8,9 @@ import java.util.Collection;
  */
 public class AdExtensionsTypeFilterConverter {
 
+    private AdExtensionsTypeFilterConverter() {
+    }
+
     public static Collection<AdExtensionsTypeFilter> convertToList(String enums) {
         String[] values = enums.split(" ");
 

--- a/proxies/com/microsoft/bingads/v10/campaignmanagement/CampaignCriterionTypeConverter.java
+++ b/proxies/com/microsoft/bingads/v10/campaignmanagement/CampaignCriterionTypeConverter.java
@@ -8,6 +8,9 @@ import java.util.Collection;
  */
 public class CampaignCriterionTypeConverter {
 
+    private CampaignCriterionTypeConverter() {
+    }
+
     public static Collection<CampaignCriterionType> convertToList(String enums) {
         String[] values = enums.split(" ");
 

--- a/proxies/com/microsoft/bingads/v10/campaignmanagement/CampaignTypeConverter.java
+++ b/proxies/com/microsoft/bingads/v10/campaignmanagement/CampaignTypeConverter.java
@@ -8,6 +8,9 @@ import java.util.Collection;
  */
 public class CampaignTypeConverter {
 
+    private CampaignTypeConverter() {
+    }
+
     public static Collection<CampaignType> convertToList(String enums) {
         String[] values = enums.split(" ");
 

--- a/proxies/com/microsoft/bingads/v10/campaignmanagement/CriterionTypeConverter.java
+++ b/proxies/com/microsoft/bingads/v10/campaignmanagement/CriterionTypeConverter.java
@@ -8,6 +8,9 @@ import java.util.Collection;
  */
 public class CriterionTypeConverter {
 
+    private CriterionTypeConverter() {
+    }
+
     public static Collection<CriterionType> convertToList(String enums) {
         String[] values = enums.split(" ");
 

--- a/proxies/com/microsoft/bingads/v10/campaignmanagement/MediaEnabledEntityFilterConverter.java
+++ b/proxies/com/microsoft/bingads/v10/campaignmanagement/MediaEnabledEntityFilterConverter.java
@@ -8,6 +8,9 @@ import java.util.Collection;
  */
 public class MediaEnabledEntityFilterConverter {
 
+    private MediaEnabledEntityFilterConverter() {
+    }
+
     public static Collection<MediaEnabledEntityFilter> convertToList(String enums) {
         String[] values = enums.split(" ");
 

--- a/src/main/java/com/microsoft/bingads/bulk/entities/ProductConditionHelper.java
+++ b/src/main/java/com/microsoft/bingads/bulk/entities/ProductConditionHelper.java
@@ -10,6 +10,9 @@ class ProductConditionHelper {
 
     public static final int MaxNumberOfConditions = 8;
 
+    private ProductConditionHelper() {
+    }
+
     public static void addRowValuesFromConditions(ArrayOfProductCondition arrayOfProductCondition, RowValues rowValues) {
         List<ProductCondition> conditions = arrayOfProductCondition.getProductConditions();
         for (int i = 1; i <= conditions.size(); i++) {

--- a/src/main/java/com/microsoft/bingads/internal/ErrorMessages.java
+++ b/src/main/java/com/microsoft/bingads/internal/ErrorMessages.java
@@ -12,6 +12,9 @@ public class ErrorMessages {
     
     public static final String OAuthError = "Couldn't request OAuth AccessTokens. Please use the getDetails() method to get more information";
 
+    private ErrorMessages() {
+    }
+
     public static String getFullOAuthAccessTokenNotRequestedMessage(Class oAuthType) {
 
         String classAndMethod = "the corresponding OAuth class method"; // in the case we add a new OAuth class and forget to update this method

--- a/src/main/java/com/microsoft/bingads/internal/HttpHeaders.java
+++ b/src/main/java/com/microsoft/bingads/internal/HttpHeaders.java
@@ -7,6 +7,9 @@ public class HttpHeaders {
     public static final String PASSWORD = "Password";
     public static final String USER_NAME = "UserName";
 
+    private HttpHeaders() {
+    }
+
     public class ContentTypes {
 
         String FORM_ENCODED = "application/x-www-form-urlencoded";

--- a/src/main/java/com/microsoft/bingads/internal/ServiceFactoryFactory.java
+++ b/src/main/java/com/microsoft/bingads/internal/ServiceFactoryFactory.java
@@ -5,7 +5,10 @@ import com.microsoft.bingads.internal.functionalinterfaces.Supplier;
 public class ServiceFactoryFactory {
     
     private static Supplier<ServiceFactory> customServiceFactorySupplier;
-    
+
+    private ServiceFactoryFactory() {
+    }
+
     public static Supplier<ServiceFactory> getCustomServiceFactorySupplier() {
         return customServiceFactorySupplier;
     }

--- a/src/main/java/com/microsoft/bingads/internal/ServiceUtils.java
+++ b/src/main/java/com/microsoft/bingads/internal/ServiceUtils.java
@@ -12,6 +12,9 @@ public class ServiceUtils {
 
     public static String TRACKING_HEADER_NAME = "TrackingId";
 
+    private ServiceUtils() {
+    }
+
     public static String GetTrackingId(Response response) {        
         Map<String, Object> context = response.getContext();
     

--- a/src/main/java/com/microsoft/bingads/internal/bulk/EntityExtractor.java
+++ b/src/main/java/com/microsoft/bingads/internal/bulk/EntityExtractor.java
@@ -8,7 +8,10 @@ import java.util.List;
 
 class EntityExtractor {
 
-     /**
+    private EntityExtractor() {
+    }
+
+    /**
      * Reserved for internal use.
      * @param entity
      * @return

--- a/src/main/java/com/microsoft/bingads/internal/bulk/MappingHelpers.java
+++ b/src/main/java/com/microsoft/bingads/internal/bulk/MappingHelpers.java
@@ -7,6 +7,9 @@ import java.util.List;
 
 public class MappingHelpers {
 
+    private MappingHelpers() {
+    }
+
     /**
      * Runs a series of mappings to populate an entity from CSV data
      *

--- a/src/main/java/com/microsoft/bingads/internal/utilities/Comparer.java
+++ b/src/main/java/com/microsoft/bingads/internal/utilities/Comparer.java
@@ -1,7 +1,10 @@
 package com.microsoft.bingads.internal.utilities;
 
 public class Comparer {
-    
+
+    private Comparer() {
+    }
+
     public static <T> Boolean compareNullable(T obj1, T obj2) {
         if (obj1 == null) {
             return obj2 == null;

--- a/src/main/java/com/microsoft/bingads/internal/utilities/FileUtils.java
+++ b/src/main/java/com/microsoft/bingads/internal/utilities/FileUtils.java
@@ -10,6 +10,9 @@ import java.io.OutputStream;
  */
 public class FileUtils {
 
+    private FileUtils() {
+    }
+
     public static void copy(InputStream in, OutputStream out) throws IOException {
 
         byte[] buf = new byte[8192];

--- a/src/main/java/com/microsoft/bingads/v10/bulk/entities/ProductConditionHelper.java
+++ b/src/main/java/com/microsoft/bingads/v10/bulk/entities/ProductConditionHelper.java
@@ -10,6 +10,9 @@ class ProductConditionHelper {
 
     public static final int MaxNumberOfConditions = 8;
 
+    private ProductConditionHelper() {
+    }
+
     public static void addRowValuesFromConditions(ArrayOfProductCondition arrayOfProductCondition, RowValues rowValues) {
         List<ProductCondition> conditions = arrayOfProductCondition.getProductConditions();
         for (int i = 1; i <= conditions.size(); i++) {

--- a/src/main/java/com/microsoft/bingads/v10/internal/bulk/CsvHeaders.java
+++ b/src/main/java/com/microsoft/bingads/v10/internal/bulk/CsvHeaders.java
@@ -184,6 +184,9 @@ public class CsvHeaders {
 
     private static final Map<String, Integer> columnIndexMap = initializeMap();
 
+    private CsvHeaders() {
+    }
+
     public static Map<String, Integer> getMappings() {
         return columnIndexMap;
     }

--- a/src/main/java/com/microsoft/bingads/v10/internal/bulk/EntityExtractor.java
+++ b/src/main/java/com/microsoft/bingads/v10/internal/bulk/EntityExtractor.java
@@ -8,7 +8,10 @@ import java.util.List;
 
 class EntityExtractor {
 
-     /**
+    private EntityExtractor() {
+    }
+
+    /**
      * Reserved for internal use.
      * @param entity
      * @return

--- a/src/main/java/com/microsoft/bingads/v10/internal/bulk/MappingHelpers.java
+++ b/src/main/java/com/microsoft/bingads/v10/internal/bulk/MappingHelpers.java
@@ -7,6 +7,9 @@ import java.util.List;
 
 public class MappingHelpers {
 
+    private MappingHelpers() {
+    }
+
     /**
      * Runs a series of mappings to populate an entity from CSV data
      *

--- a/src/test/java/com/microsoft/bingads/api/test/entities/Util.java
+++ b/src/test/java/com/microsoft/bingads/api/test/entities/Util.java
@@ -16,6 +16,9 @@ import java.util.ArrayList;
 
 public class Util {
 
+    private Util() {
+    }
+
     public static synchronized ArrayList<BulkEntity> WriteAndReadBack(ArrayList<BulkEntity> entities) {
         ArrayList<BulkEntity> results = new ArrayList<BulkEntity>();
         try {

--- a/src/test/java/com/microsoft/bingads/v10/api/test/entities/Util.java
+++ b/src/test/java/com/microsoft/bingads/v10/api/test/entities/Util.java
@@ -16,6 +16,9 @@ import java.util.ArrayList;
 
 public class Util {
 
+    private Util() {
+    }
+
     public static synchronized ArrayList<BulkEntity> WriteAndReadBack(ArrayList<BulkEntity> entities) {
         ArrayList<BulkEntity> results = new ArrayList<BulkEntity>();
         try {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.