### PR TITLE
Null pointers should not be dereferenced

### DIFF
--- a/examples/BingAdsDesktopApp/v9/BulkDownloadUpload.java
+++ b/examples/BingAdsDesktopApp/v9/BulkDownloadUpload.java
@@ -408,11 +408,18 @@ public class BulkDownloadUpload extends BulkExampleBaseV9 {
         }
         finally
         {
-            reader.close();
-            writer.flush();
-            writer.close();
-            out.flush();
-            out.close();
+            if (reader != null)
+                reader.close();
+                
+            if (writer != null) {
+                writer.flush();
+                writer.close();
+            }
+            
+            if (out != null) {
+                out.flush();
+                out.close();
+            }
         }
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2259 - “Null pointers should not be dereferenced”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2259
Please let me know if you have any questions.
Ayman Abdelghany.