### PR TITLE
 Fixing code quality issues: squid:S1854 - squid:S2864

### DIFF
--- a/src/main/java/com/microsoft/bingads/bulk/entities/BulkCampaignNegativeKeywordList.java
+++ b/src/main/java/com/microsoft/bingads/bulk/entities/BulkCampaignNegativeKeywordList.java
@@ -46,7 +46,6 @@ public class BulkCampaignNegativeKeywordList extends SingleRecordBulkEntity {
     static {
         List<BulkMapping<BulkCampaignNegativeKeywordList>> m = new ArrayList<BulkMapping<BulkCampaignNegativeKeywordList>>();
 
-        AdExtensionStatus a;
         m.add(new SimpleBulkMapping<BulkCampaignNegativeKeywordList, String>(StringTable.Status,
                 new Function<BulkCampaignNegativeKeywordList, String>() {
                     @Override

--- a/src/main/java/com/microsoft/bingads/internal/bulk/RowValues.java
+++ b/src/main/java/com/microsoft/bingads/internal/bulk/RowValues.java
@@ -22,8 +22,8 @@ public class RowValues {
         this.mappings = CsvHeaders.getMappings();
         this.columns = new String[this.mappings.keySet().size()];
 
-        for (String key : rowValues.keySet()) {
-            this.put(key, rowValues.get(key));
+        for (Entry<String, String> stringStringEntry : rowValues.entrySet()) {
+            this.put(stringStringEntry.getKey(), stringStringEntry.getValue());
         }
     }
 

--- a/src/main/java/com/microsoft/bingads/v10/bulk/entities/BulkCampaignNegativeKeywordList.java
+++ b/src/main/java/com/microsoft/bingads/v10/bulk/entities/BulkCampaignNegativeKeywordList.java
@@ -47,7 +47,6 @@ public class BulkCampaignNegativeKeywordList extends SingleRecordBulkEntity {
     static {
         List<BulkMapping<BulkCampaignNegativeKeywordList>> m = new ArrayList<BulkMapping<BulkCampaignNegativeKeywordList>>();
 
-        AdExtensionStatus a;
         m.add(new SimpleBulkMapping<BulkCampaignNegativeKeywordList, String>(StringTable.Status,
                 new Function<BulkCampaignNegativeKeywordList, String>() {
                     @Override

--- a/src/main/java/com/microsoft/bingads/v10/internal/bulk/RowValues.java
+++ b/src/main/java/com/microsoft/bingads/v10/internal/bulk/RowValues.java
@@ -22,8 +22,8 @@ public class RowValues {
         this.mappings = CsvHeaders.getMappings();
         this.columns = new String[this.mappings.keySet().size()];
 
-        for (String key : rowValues.keySet()) {
-            this.put(key, rowValues.get(key));
+        for (Entry<String, String> stringStringEntry : rowValues.entrySet()) {
+            this.put(stringStringEntry.getKey(), stringStringEntry.getValue());
         }
     }
 

--- a/src/test/java/com/microsoft/bingads/api/test/entities/RowValuesAssert.java
+++ b/src/test/java/com/microsoft/bingads/api/test/entities/RowValuesAssert.java
@@ -7,8 +7,8 @@ import static org.junit.Assert.assertEquals;
 public class RowValuesAssert {
 
     public static void assertContains(Map<String, String> expected, RowValues actual) {        
-        for (String expectedKey : expected.keySet()) {
-            assertEquals(expected.get(expectedKey), actual.get(expectedKey));
+        for (Map.Entry<String, String> stringStringEntry : expected.entrySet()) {
+            assertEquals(stringStringEntry.getValue(), actual.get(stringStringEntry.getKey()));
         }
     }
 }

--- a/src/test/java/com/microsoft/bingads/api/test/operations/bulk_download_operation/TrackTest.java
+++ b/src/test/java/com/microsoft/bingads/api/test/operations/bulk_download_operation/TrackTest.java
@@ -53,7 +53,7 @@ public class TrackTest extends BulkDownloadOperationTest {
 
         TestProgress progress = new TestProgress();
 
-        BulkOperationStatus<DownloadStatus> actualStatus = null;
+        BulkOperationStatus<DownloadStatus> actualStatus;
 
         actualStatus = operation.trackAsync(progress, null).get();
 

--- a/src/test/java/com/microsoft/bingads/v10/api/test/entities/RowValuesAssert.java
+++ b/src/test/java/com/microsoft/bingads/v10/api/test/entities/RowValuesAssert.java
@@ -7,8 +7,8 @@ import static org.junit.Assert.assertEquals;
 public class RowValuesAssert {
 
     public static void assertContains(Map<String, String> expected, RowValues actual) {        
-        for (String expectedKey : expected.keySet()) {
-            assertEquals(expected.get(expectedKey), actual.get(expectedKey));
+        for (Map.Entry<String, String> stringStringEntry : expected.entrySet()) {
+            assertEquals(stringStringEntry.getValue(), actual.get(stringStringEntry.getKey()));
         }
     }
 }

--- a/src/test/java/com/microsoft/bingads/v10/api/test/entities/campaign/write/BulkCampaignWriteToRowValuesUrlCustomParameters.java
+++ b/src/test/java/com/microsoft/bingads/v10/api/test/entities/campaign/write/BulkCampaignWriteToRowValuesUrlCustomParameters.java
@@ -67,7 +67,7 @@ public class BulkCampaignWriteToRowValuesUrlCustomParameters extends BulkCampaig
 		CustomParameter paraTest2 = new CustomParameter();
 		paraTest2.setKey("key2");
 		paraTest2.setValue("value\\2");
-		ArrayOfCustomParameter array = new ArrayOfCustomParameter();
+		ArrayOfCustomParameter array;
 		array = new ArrayOfCustomParameter();
 		array.getCustomParameters().add(paraTest1);
 		array.getCustomParameters().add(paraTest2);

--- a/src/test/java/com/microsoft/bingads/v10/api/test/entities/keyword/write/BulkKeywordWriteToRowValuesUrlCustomParameters.java
+++ b/src/test/java/com/microsoft/bingads/v10/api/test/entities/keyword/write/BulkKeywordWriteToRowValuesUrlCustomParameters.java
@@ -71,7 +71,7 @@ public class BulkKeywordWriteToRowValuesUrlCustomParameters extends BulkKeywordT
 		CustomParameter paraTest2 = new CustomParameter();
 		paraTest2.setKey("key2");
 		paraTest2.setValue("value\\2");
-		ArrayOfCustomParameter array = new ArrayOfCustomParameter();
+		ArrayOfCustomParameter array;
 		array = new ArrayOfCustomParameter();
 		array.getCustomParameters().add(paraTest1);
 		array.getCustomParameters().add(paraTest2);

--- a/src/test/java/com/microsoft/bingads/v10/api/test/operations/bulk_download_operation/TrackTest.java
+++ b/src/test/java/com/microsoft/bingads/v10/api/test/operations/bulk_download_operation/TrackTest.java
@@ -53,7 +53,7 @@ public class TrackTest extends BulkDownloadOperationTest {
 
         TestProgress progress = new TestProgress();
 
-        BulkOperationStatus<DownloadStatus> actualStatus = null;
+        BulkOperationStatus<DownloadStatus> actualStatus;
 
         actualStatus = operation.trackAsync(progress, null).get();
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S2864 - “"entrySet()" should be iterated when both the key and value are needed ”.
squid:S1854 - “ Dead stores should be removed ”.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2864
https://dev.eclipse.org/sonar/rules/show/squid:S1854
Please let me know if you have any questions.
Ayman Abdelghany.