### PR TITLE
Avoid exceptions when parsing empty strings

### DIFF
--- a/src/main/java/com/microsoft/bingads/v10/internal/bulk/StringExtensions.java
+++ b/src/main/java/com/microsoft/bingads/v10/internal/bulk/StringExtensions.java
@@ -91,6 +91,10 @@ public class StringExtensions {
      * @return a Double or a null if the value is not parseable as a double
      */
     public static Double nullOrDouble(String value) {
+        if (isNullOrEmpty(value)) {
+            return null;
+        }
+
         try {
             return Double.parseDouble(value);
         } catch (NumberFormatException e) {


### PR DESCRIPTION
StringExtensions#nullOrDouble(String) will be sometimes called with an empty String. This will result in an unnecessary NumberFormatException in Double.parseDouble(String) which will be ignored. This unnecessarily hurts the performance. This PR simply adds a non-empty check at the start of StringExtensions#nullOrDouble(String).

The location the StringExtensions.nullOrDouble("") calls come from:
at com.microsoft.bingads.v10.internal.bulk.StringExtensions.nullOrDouble(StringExtensions.java:101) [classes/:?]
at com.microsoft.bingads.v10.bulk.entities.PerformanceData$18.accept(PerformanceData.java:179) [microsoft.bingads-10.4.2.jar:?]
at com.microsoft.bingads.v10.bulk.entities.PerformanceData$18.accept(PerformanceData.java:176) [microsoft.bingads-10.4.2.jar:?]
at com.microsoft.bingads.v10.internal.bulk.SingleFieldBulkMapping.convertToEntity(SingleFieldBulkMapping.java:32) [microsoft.bingads-10.4.2.jar:?]
at com.microsoft.bingads.v10.internal.bulk.SimpleBulkMapping.convertToEntity(SimpleBulkMapping.java:15) [microsoft.bingads-10.4.2.jar:?]
at com.microsoft.bingads.v10.internal.bulk.MappingHelpers.convertToEntity(MappingHelpers.java:20) [microsoft.bingads-10.4.2.jar:?]
at com.microsoft.bingads.v10.bulk.entities.PerformanceData.readFromRowValues(PerformanceData.java:301) [microsoft.bingads-10.4.2.jar:?]
at com.microsoft.bingads.v10.bulk.entities.BulkKeywordBidSuggestion.readFromRowValues(BulkKeywordBidSuggestion.java:90) [microsoft.bingads-10.4.2.jar:?]
at com.microsoft.bingads.v10.internal.bulk.SimpleBulkObjectReader.readNextBulkObject(SimpleBulkObjectReader.java:122) [microsoft.bingads-10.4.2.jar:?]
at com.microsoft.bingads.v10.internal.bulk.SimpleBulkStreamReader.peek(SimpleBulkStreamReader.java:107) [microsoft.bingads-10.4.2.jar:?]
at com.microsoft.bingads.v10.internal.bulk.SimpleBulkStreamReader.tryRead(SimpleBulkStreamReader.java:73) [microsoft.bingads-10.4.2.jar:?]
at com.microsoft.bingads.v10.internal.bulk.SimpleBulkStreamReader.tryRead(SimpleBulkStreamReader.java:54) [microsoft.bingads-10.4.2.jar:?]
at com.microsoft.bingads.v10.bulk.entities.BulkKeyword.readAdditionalData(BulkKeyword.java:411) [microsoft.bingads-10.4.2.jar:?]
at com.microsoft.bingads.v10.internal.bulk.entities.SingleRecordBulkEntity.readRelatedDataFromStream(SingleRecordBulkEntity.java:143) [microsoft.bingads-10.4.2.jar:?]
at com.microsoft.bingads.v10.internal.bulk.SimpleBulkStreamReader.tryRead(SimpleBulkStreamReader.java:79) [microsoft.bingads-10.4.2.jar:?]
at com.microsoft.bingads.v10.internal.bulk.SimpleBulkStreamReader.tryRead(SimpleBulkStreamReader.java:54) [microsoft.bingads-10.4.2.jar:?]
at com.microsoft.bingads.v10.internal.bulk.SimpleBulkStreamReader.read(SimpleBulkStreamReader.java:36) [microsoft.bingads-10.4.2.jar:?]
at com.microsoft.bingads.v10.internal.bulk.EntityIterator.readNextBatch(EntityIterator.java:53) [microsoft.bingads-10.4.2.jar:?]
at com.microsoft.bingads.v10.internal.bulk.EntityIterator.updateNextBatch(EntityIterator.java:45) [microsoft.bingads-10.4.2.jar:?]
at com.microsoft.bingads.v10.internal.bulk.EntityIterator.hasNext(EntityIterator.java:26) [microsoft.bingads-10.4.2.jar:?]
