### PR TITLE
Make tests OS independent

### DIFF
--- a/src/test/java/com/microsoft/bingads/v10/api/test/operations/BulkServiceTest.java
+++ b/src/test/java/com/microsoft/bingads/v10/api/test/operations/BulkServiceTest.java
@@ -238,9 +238,9 @@ public class BulkServiceTest extends FakeApiTest {
         
         ZipExtractor zipExtractor = createMock(ZipExtractor.class);
           
-        File expectedZipFile = new File(System.getProperty("java.io.tmpdir"), "BingAdsSDK\\req456.zip");
+        File expectedZipFile = new File(new File(System.getProperty("java.io.tmpdir"), "BingAdsSDK"), "req456.zip");
         
-        File expectedResultFile = new File(System.getProperty("java.io.tmpdir"), "BingAdsSDK\\req456");
+        File expectedResultFile = new File(new File(System.getProperty("java.io.tmpdir"), "BingAdsSDK"), "req456");
         
         expect(zipExtractor.extractFirstEntryToFile(expectedZipFile, expectedResultFile, true, false)).andReturn(new File("file path"));
         
@@ -333,9 +333,9 @@ public class BulkServiceTest extends FakeApiTest {
         
         ZipExtractor zipExtractor = createMock(ZipExtractor.class);
           
-        File expectedZipFile = new File(System.getProperty("java.io.tmpdir"), "BingAdsSDK\\req456.zip");
+        File expectedZipFile = new File(new File(System.getProperty("java.io.tmpdir"), "BingAdsSDK"), "req456.zip");
         
-        File expectedResultFile = new File(System.getProperty("java.io.tmpdir"), "BingAdsSDK\\req456");
+        File expectedResultFile = new File(new File(System.getProperty("java.io.tmpdir"), "BingAdsSDK"), "req456");
         
         expect(zipExtractor.extractFirstEntryToFile(expectedZipFile, expectedResultFile, true, false)).andReturn(new File("file path"));
         


### PR DESCRIPTION
Not every OS uses backslashes as file separator ;-)