### PR TITLE
set environment for new BulkDownloadOperation

### DIFF
--- a/examples/BingAdsDesktopApp/src/main/java/com/microsoft/bingads/examples/v11/BulkServiceManagerDemo.java
+++ b/examples/BingAdsDesktopApp/src/main/java/com/microsoft/bingads/examples/v11/BulkServiceManagerDemo.java
@@ -347,7 +347,7 @@ public class BulkServiceManagerDemo extends BulkExampleBase {
         throws ExecutionException, InterruptedException, URISyntaxException, IOException, TimeoutException 
     {
 
-        BulkDownloadOperation bulkDownloadOperation = new BulkDownloadOperation(requestId, authorizationData);
+        BulkDownloadOperation bulkDownloadOperation = new BulkDownloadOperation(requestId, authorizationData, API_ENVIRONMENT);
 
         bulkDownloadOperation.setStatusPollIntervalInMilliseconds(5000);
 

--- a/examples/BingAdsDesktopApp/src/main/java/com/microsoft/bingads/examples/v11/ReportRequests.java
+++ b/examples/BingAdsDesktopApp/src/main/java/com/microsoft/bingads/examples/v11/ReportRequests.java
@@ -230,7 +230,7 @@ public class ReportRequests extends ExampleBase {
     private static void downloadResultsAsync(java.lang.String requestId) 
         throws ExecutionException, InterruptedException, URISyntaxException, IOException, TimeoutException {
 
-        ReportingDownloadOperation reportingDownloadOperation = new ReportingDownloadOperation(requestId, authorizationData);
+        ReportingDownloadOperation reportingDownloadOperation = new ReportingDownloadOperation(requestId, authorizationData, API_ENVIRONMENT);
 
         reportingDownloadOperation.setStatusPollIntervalInMilliseconds(5000);
 


### PR DESCRIPTION
The environment for each new BulkDownloadOperation and ReportingDownloadOperation default to production. Override the default environment as needed.