### PR TITLE
Fix handling of text asset links

### DIFF
--- a/src/main/java/com/microsoft/bingads/v13/internal/bulk/StringExtensions.java
+++ b/src/main/java/com/microsoft/bingads/v13/internal/bulk/StringExtensions.java
@@ -1453,7 +1453,7 @@ public class StringExtensions {
     private static class ImageAssetLinkContract
     {
         // The Asset Id
-        public long id;
+        public Long id;
 
         // The Asset SubType
         public String subType;
@@ -1520,7 +1520,7 @@ public class StringExtensions {
         List<AssetLink> assetLinks = arrayOfAssetLink
                 .getAssetLinks()
                 .stream()
-                .filter(s -> "ImageAsset".equals(s.getAsset().getType()))
+                .filter(link -> link.getAsset() instanceof ImageAsset)
                 .collect(Collectors.toList());
         if (assetLinks.size() == 0) {
             return null;

--- a/src/main/java/com/microsoft/bingads/v13/internal/bulk/StringExtensions.java
+++ b/src/main/java/com/microsoft/bingads/v13/internal/bulk/StringExtensions.java
@@ -1487,7 +1487,7 @@ public class StringExtensions {
 
         // The Asset Id
         @JsonProperty
-        public long id;
+        public Long id;
 
         // The Asset Text
         @JsonProperty
@@ -1603,7 +1603,7 @@ public class StringExtensions {
         List<AssetLink> assetLinks = arrayOfAssetLink
                 .getAssetLinks()
                 .stream()
-                .filter(s -> "TextAsset".equals(s.getAsset().getType()))
+                .filter(link -> link.getAsset() instanceof TextAsset)
                 .collect(Collectors.toList());
         if (assetLinks.size() == 0) {
             return null;


### PR DESCRIPTION
This should fix the rendering text assets links for bulk CSVs (#107). But most probably this fix should be done the same way for image asset links too.