### PR TITLE
v13.0.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Bing Ads Java SDK includes and depends on the microsoft.bingads Maven artifa
 <dependency>
   <groupId>com.microsoft.bingads</groupId>
   <artifactId>microsoft.bingads</artifactId>
-  <version>13.0.13</version>
+  <version>13.0.14</version>
 </dependency>
 ```
 If you are not using a Maven project, you must include the correct version of each dependency. You can review the complete list of Bing Ads Java SDK dependencies at the [Maven Repository](http://mvnrepository.com/artifact/com.microsoft.bingads/microsoft.bingads/).

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.bingads</groupId>
-    <version>13.0.13</version>
+    <version>13.0.14</version>
     <name>Bing Ads Java SDK</name>
     <description>The Bing Ads Java SDK is a library improving developer experience when working with the Bing Ads services by providing high-level access to features such as Bulk API, OAuth Authorization and SOAP API.</description>
     <url>https://github.com/BingAds/BingAds-Java-SDK</url>

--- a/proxies/com/microsoft/bingads/v13/adinsight/ArrayOfAutoApplyRecommendationsInfo.java
+++ b/proxies/com/microsoft/bingads/v13/adinsight/ArrayOfAutoApplyRecommendationsInfo.java
@@ -1,0 +1,69 @@
+
+package com.microsoft.bingads.v13.adinsight;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java class for ArrayOfAutoApplyRecommendationsInfo complex type.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ * 
+ * <pre>
+ * &lt;complexType name="ArrayOfAutoApplyRecommendationsInfo">
+ *   &lt;complexContent>
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       &lt;sequence>
+ *         &lt;element name="AutoApplyRecommendationsInfo" type="{https://bingads.microsoft.com/AdInsight/v13}AutoApplyRecommendationsInfo" maxOccurs="unbounded" minOccurs="0"/>
+ *       &lt;/sequence>
+ *     &lt;/restriction>
+ *   &lt;/complexContent>
+ * &lt;/complexType>
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "ArrayOfAutoApplyRecommendationsInfo", propOrder = {
+    "autoApplyRecommendationsInfos"
+})
+public class ArrayOfAutoApplyRecommendationsInfo {
+
+    @XmlElement(name = "AutoApplyRecommendationsInfo", nillable = true)
+    protected List<AutoApplyRecommendationsInfo> autoApplyRecommendationsInfos;
+
+    /**
+     * Gets the value of the autoApplyRecommendationsInfos property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the autoApplyRecommendationsInfos property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getAutoApplyRecommendationsInfos().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link AutoApplyRecommendationsInfo }
+     * 
+     * 
+     */
+    public List<AutoApplyRecommendationsInfo> getAutoApplyRecommendationsInfos() {
+        if (autoApplyRecommendationsInfos == null) {
+            autoApplyRecommendationsInfos = new ArrayList<AutoApplyRecommendationsInfo>();
+        }
+        return this.autoApplyRecommendationsInfos;
+    }
+
+}

--- a/proxies/com/microsoft/bingads/v13/adinsight/ArrayOfEntityDetail.java
+++ b/proxies/com/microsoft/bingads/v13/adinsight/ArrayOfEntityDetail.java
@@ -1,0 +1,69 @@
+
+package com.microsoft.bingads.v13.adinsight;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java class for ArrayOfEntityDetail complex type.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ * 
+ * <pre>
+ * &lt;complexType name="ArrayOfEntityDetail">
+ *   &lt;complexContent>
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       &lt;sequence>
+ *         &lt;element name="EntityDetail" type="{https://bingads.microsoft.com/AdInsight/v13}EntityDetail" maxOccurs="unbounded" minOccurs="0"/>
+ *       &lt;/sequence>
+ *     &lt;/restriction>
+ *   &lt;/complexContent>
+ * &lt;/complexType>
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "ArrayOfEntityDetail", propOrder = {
+    "entityDetails"
+})
+public class ArrayOfEntityDetail {
+
+    @XmlElement(name = "EntityDetail", nillable = true)
+    protected List<EntityDetail> entityDetails;
+
+    /**
+     * Gets the value of the entityDetails property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the entityDetails property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getEntityDetails().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link EntityDetail }
+     * 
+     * 
+     */
+    public List<EntityDetail> getEntityDetails() {
+        if (entityDetails == null) {
+            entityDetails = new ArrayList<EntityDetail>();
+        }
+        return this.entityDetails;
+    }
+
+}

--- a/proxies/com/microsoft/bingads/v13/adinsight/ArrayOfPerformanceInsightsDetail.java
+++ b/proxies/com/microsoft/bingads/v13/adinsight/ArrayOfPerformanceInsightsDetail.java
@@ -1,0 +1,69 @@
+
+package com.microsoft.bingads.v13.adinsight;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java class for ArrayOfPerformanceInsightsDetail complex type.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ * 
+ * <pre>
+ * &lt;complexType name="ArrayOfPerformanceInsightsDetail">
+ *   &lt;complexContent>
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       &lt;sequence>
+ *         &lt;element name="PerformanceInsightsDetail" type="{https://bingads.microsoft.com/AdInsight/v13}PerformanceInsightsDetail" maxOccurs="unbounded" minOccurs="0"/>
+ *       &lt;/sequence>
+ *     &lt;/restriction>
+ *   &lt;/complexContent>
+ * &lt;/complexType>
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "ArrayOfPerformanceInsightsDetail", propOrder = {
+    "performanceInsightsDetails"
+})
+public class ArrayOfPerformanceInsightsDetail {
+
+    @XmlElement(name = "PerformanceInsightsDetail", nillable = true)
+    protected List<PerformanceInsightsDetail> performanceInsightsDetails;
+
+    /**
+     * Gets the value of the performanceInsightsDetails property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the performanceInsightsDetails property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getPerformanceInsightsDetails().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link PerformanceInsightsDetail }
+     * 
+     * 
+     */
+    public List<PerformanceInsightsDetail> getPerformanceInsightsDetails() {
+        if (performanceInsightsDetails == null) {
+            performanceInsightsDetails = new ArrayList<PerformanceInsightsDetail>();
+        }
+        return this.performanceInsightsDetails;
+    }
+
+}

--- a/proxies/com/microsoft/bingads/v13/adinsight/ArrayOfPerformanceInsightsMessage.java
+++ b/proxies/com/microsoft/bingads/v13/adinsight/ArrayOfPerformanceInsightsMessage.java
@@ -1,0 +1,69 @@
+
+package com.microsoft.bingads.v13.adinsight;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java class for ArrayOfPerformanceInsightsMessage complex type.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ * 
+ * <pre>
+ * &lt;complexType name="ArrayOfPerformanceInsightsMessage">
+ *   &lt;complexContent>
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       &lt;sequence>
+ *         &lt;element name="PerformanceInsightsMessage" type="{https://bingads.microsoft.com/AdInsight/v13}PerformanceInsightsMessage" maxOccurs="unbounded" minOccurs="0"/>
+ *       &lt;/sequence>
+ *     &lt;/restriction>
+ *   &lt;/complexContent>
+ * &lt;/complexType>
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "ArrayOfPerformanceInsightsMessage", propOrder = {
+    "performanceInsightsMessages"
+})
+public class ArrayOfPerformanceInsightsMessage {
+
+    @XmlElement(name = "PerformanceInsightsMessage", nillable = true)
+    protected List<PerformanceInsightsMessage> performanceInsightsMessages;
+
+    /**
+     * Gets the value of the performanceInsightsMessages property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the performanceInsightsMessages property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getPerformanceInsightsMessages().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link PerformanceInsightsMessage }
+     * 
+     * 
+     */
+    public List<PerformanceInsightsMessage> getPerformanceInsightsMessages() {
+        if (performanceInsightsMessages == null) {
+            performanceInsightsMessages = new ArrayList<PerformanceInsightsMessage>();
+        }
+        return this.performanceInsightsMessages;
+    }
+
+}

--- a/proxies/com/microsoft/bingads/v13/adinsight/ArrayOfPerformanceInsightsMessageParameter.java
+++ b/proxies/com/microsoft/bingads/v13/adinsight/ArrayOfPerformanceInsightsMessageParameter.java
@@ -1,0 +1,69 @@
+
+package com.microsoft.bingads.v13.adinsight;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java class for ArrayOfPerformanceInsightsMessageParameter complex type.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ * 
+ * <pre>
+ * &lt;complexType name="ArrayOfPerformanceInsightsMessageParameter">
+ *   &lt;complexContent>
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       &lt;sequence>
+ *         &lt;element name="PerformanceInsightsMessageParameter" type="{https://bingads.microsoft.com/AdInsight/v13}PerformanceInsightsMessageParameter" maxOccurs="unbounded" minOccurs="0"/>
+ *       &lt;/sequence>
+ *     &lt;/restriction>
+ *   &lt;/complexContent>
+ * &lt;/complexType>
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "ArrayOfPerformanceInsightsMessageParameter", propOrder = {
+    "performanceInsightsMessageParameters"
+})
+public class ArrayOfPerformanceInsightsMessageParameter {
+
+    @XmlElement(name = "PerformanceInsightsMessageParameter", nillable = true)
+    protected List<PerformanceInsightsMessageParameter> performanceInsightsMessageParameters;
+
+    /**
+     * Gets the value of the performanceInsightsMessageParameters property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the performanceInsightsMessageParameters property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getPerformanceInsightsMessageParameters().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link PerformanceInsightsMessageParameter }
+     * 
+     * 
+     */
+    public List<PerformanceInsightsMessageParameter> getPerformanceInsightsMessageParameters() {
+        if (performanceInsightsMessageParameters == null) {
+            performanceInsightsMessageParameters = new ArrayList<PerformanceInsightsMessageParameter>();
+        }
+        return this.performanceInsightsMessageParameters;
+    }
+
+}

--- a/proxies/com/microsoft/bingads/v13/adinsight/AutoApplyRecommendationsInfo.java
+++ b/proxies/com/microsoft/bingads/v13/adinsight/AutoApplyRecommendationsInfo.java
@@ -1,0 +1,90 @@
+
+package com.microsoft.bingads.v13.adinsight;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java class for AutoApplyRecommendationsInfo complex type.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ * 
+ * <pre>
+ * &lt;complexType name="AutoApplyRecommendationsInfo">
+ *   &lt;complexContent>
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       &lt;sequence>
+ *         &lt;element name="AAROptInStatus" type="{http://www.w3.org/2001/XMLSchema}boolean" minOccurs="0"/>
+ *         &lt;element name="RecommendationType" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/>
+ *       &lt;/sequence>
+ *     &lt;/restriction>
+ *   &lt;/complexContent>
+ * &lt;/complexType>
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "AutoApplyRecommendationsInfo", propOrder = {
+    "aarOptInStatus",
+    "recommendationType"
+})
+public class AutoApplyRecommendationsInfo {
+
+    @XmlElement(name = "AAROptInStatus")
+    protected Boolean aarOptInStatus;
+    @XmlElement(name = "RecommendationType", nillable = true)
+    protected String recommendationType;
+
+    /**
+     * Gets the value of the aarOptInStatus property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link Boolean }
+     *     
+     */
+    public Boolean getAAROptInStatus() {
+        return aarOptInStatus;
+    }
+
+    /**
+     * Sets the value of the aarOptInStatus property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link Boolean }
+     *     
+     */
+    public void setAAROptInStatus(Boolean value) {
+        this.aarOptInStatus = value;
+    }
+
+    /**
+     * Gets the value of the recommendationType property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getRecommendationType() {
+        return recommendationType;
+    }
+
+    /**
+     * Sets the value of the recommendationType property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setRecommendationType(String value) {
+        this.recommendationType = value;
+    }
+
+}

--- a/proxies/com/microsoft/bingads/v13/adinsight/EntityDetail.java
+++ b/proxies/com/microsoft/bingads/v13/adinsight/EntityDetail.java
@@ -1,0 +1,90 @@
+
+package com.microsoft.bingads.v13.adinsight;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java class for EntityDetail complex type.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ * 
+ * <pre>
+ * &lt;complexType name="EntityDetail">
+ *   &lt;complexContent>
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       &lt;sequence>
+ *         &lt;element name="EntityId" type="{http://www.w3.org/2001/XMLSchema}long" minOccurs="0"/>
+ *         &lt;element name="EntityName" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/>
+ *       &lt;/sequence>
+ *     &lt;/restriction>
+ *   &lt;/complexContent>
+ * &lt;/complexType>
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "EntityDetail", propOrder = {
+    "entityId",
+    "entityName"
+})
+public class EntityDetail {
+
+    @XmlElement(name = "EntityId")
+    protected Long entityId;
+    @XmlElement(name = "EntityName", nillable = true)
+    protected String entityName;
+
+    /**
+     * Gets the value of the entityId property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link Long }
+     *     
+     */
+    public Long getEntityId() {
+        return entityId;
+    }
+
+    /**
+     * Sets the value of the entityId property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link Long }
+     *     
+     */
+    public void setEntityId(Long value) {
+        this.entityId = value;
+    }
+
+    /**
+     * Gets the value of the entityName property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getEntityName() {
+        return entityName;
+    }
+
+    /**
+     * Sets the value of the entityName property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setEntityName(String value) {
+        this.entityName = value;
+    }
+
+}

--- a/proxies/com/microsoft/bingads/v13/adinsight/EntityParameter.java
+++ b/proxies/com/microsoft/bingads/v13/adinsight/EntityParameter.java
@@ -1,0 +1,150 @@
+
+package com.microsoft.bingads.v13.adinsight;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlSchemaType;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java class for EntityParameter complex type.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ * 
+ * <pre>
+ * &lt;complexType name="EntityParameter">
+ *   &lt;complexContent>
+ *     &lt;extension base="{https://bingads.microsoft.com/AdInsight/v13}PerformanceInsightsMessageParameter">
+ *       &lt;sequence>
+ *         &lt;element name="EntityCount" type="{http://www.w3.org/2001/XMLSchema}int" minOccurs="0"/>
+ *         &lt;element name="EntityDetails" type="{https://bingads.microsoft.com/AdInsight/v13}ArrayOfEntityDetail" minOccurs="0"/>
+ *         &lt;element name="EntityType" type="{https://bingads.microsoft.com/AdInsight/v13}PerformanceInsightsEntityType" minOccurs="0"/>
+ *         &lt;element name="SuggestedText" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/>
+ *       &lt;/sequence>
+ *     &lt;/extension>
+ *   &lt;/complexContent>
+ * &lt;/complexType>
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "EntityParameter", propOrder = {
+    "entityCount",
+    "entityDetails",
+    "entityType",
+    "suggestedText"
+})
+public class EntityParameter
+    extends PerformanceInsightsMessageParameter
+{
+
+    @XmlElement(name = "EntityCount")
+    protected Integer entityCount;
+    @XmlElement(name = "EntityDetails", nillable = true)
+    protected ArrayOfEntityDetail entityDetails;
+    @XmlElement(name = "EntityType")
+    @XmlSchemaType(name = "string")
+    protected PerformanceInsightsEntityType entityType;
+    @XmlElement(name = "SuggestedText", nillable = true)
+    protected String suggestedText;
+
+    /**
+     * Gets the value of the entityCount property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link Integer }
+     *     
+     */
+    public Integer getEntityCount() {
+        return entityCount;
+    }
+
+    /**
+     * Sets the value of the entityCount property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link Integer }
+     *     
+     */
+    public void setEntityCount(Integer value) {
+        this.entityCount = value;
+    }
+
+    /**
+     * Gets the value of the entityDetails property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link ArrayOfEntityDetail }
+     *     
+     */
+    public ArrayOfEntityDetail getEntityDetails() {
+        return entityDetails;
+    }
+
+    /**
+     * Sets the value of the entityDetails property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link ArrayOfEntityDetail }
+     *     
+     */
+    public void setEntityDetails(ArrayOfEntityDetail value) {
+        this.entityDetails = value;
+    }
+
+    /**
+     * Gets the value of the entityType property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link PerformanceInsightsEntityType }
+     *     
+     */
+    public PerformanceInsightsEntityType getEntityType() {
+        return entityType;
+    }
+
+    /**
+     * Sets the value of the entityType property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link PerformanceInsightsEntityType }
+     *     
+     */
+    public void setEntityType(PerformanceInsightsEntityType value) {
+        this.entityType = value;
+    }
+
+    /**
+     * Gets the value of the suggestedText property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getSuggestedText() {
+        return suggestedText;
+    }
+
+    /**
+     * Sets the value of the suggestedText property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setSuggestedText(String value) {
+        this.suggestedText = value;
+    }
+
+}

--- a/proxies/com/microsoft/bingads/v13/adinsight/GetAutoApplyOptInStatusRequest.java
+++ b/proxies/com/microsoft/bingads/v13/adinsight/GetAutoApplyOptInStatusRequest.java
@@ -1,0 +1,64 @@
+
+package com.microsoft.bingads.v13.adinsight;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java class for anonymous complex type.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ * 
+ * <pre>
+ * &lt;complexType>
+ *   &lt;complexContent>
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       &lt;sequence>
+ *         &lt;element name="RecommendationTypesInputs" type="{http://schemas.microsoft.com/2003/10/Serialization/Arrays}ArrayOfstring" minOccurs="0"/>
+ *       &lt;/sequence>
+ *     &lt;/restriction>
+ *   &lt;/complexContent>
+ * &lt;/complexType>
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "recommendationTypesInputs"
+})
+@XmlRootElement(name = "GetAutoApplyOptInStatusRequest")
+public class GetAutoApplyOptInStatusRequest {
+
+    @XmlElement(name = "RecommendationTypesInputs", nillable = true)
+    protected ArrayOfstring recommendationTypesInputs;
+
+    /**
+     * Gets the value of the recommendationTypesInputs property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link ArrayOfstring }
+     *     
+     */
+    public ArrayOfstring getRecommendationTypesInputs() {
+        return recommendationTypesInputs;
+    }
+
+    /**
+     * Sets the value of the recommendationTypesInputs property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link ArrayOfstring }
+     *     
+     */
+    public void setRecommendationTypesInputs(ArrayOfstring value) {
+        this.recommendationTypesInputs = value;
+    }
+
+}

--- a/proxies/com/microsoft/bingads/v13/adinsight/GetAutoApplyOptInStatusResponse.java
+++ b/proxies/com/microsoft/bingads/v13/adinsight/GetAutoApplyOptInStatusResponse.java
@@ -1,0 +1,64 @@
+
+package com.microsoft.bingads.v13.adinsight;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java class for anonymous complex type.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ * 
+ * <pre>
+ * &lt;complexType>
+ *   &lt;complexContent>
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       &lt;sequence>
+ *         &lt;element name="AutoApplyRecommendationsStatus" type="{https://bingads.microsoft.com/AdInsight/v13}ArrayOfAutoApplyRecommendationsInfo" minOccurs="0"/>
+ *       &lt;/sequence>
+ *     &lt;/restriction>
+ *   &lt;/complexContent>
+ * &lt;/complexType>
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "autoApplyRecommendationsStatus"
+})
+@XmlRootElement(name = "GetAutoApplyOptInStatusResponse")
+public class GetAutoApplyOptInStatusResponse {
+
+    @XmlElement(name = "AutoApplyRecommendationsStatus", nillable = true)
+    protected ArrayOfAutoApplyRecommendationsInfo autoApplyRecommendationsStatus;
+
+    /**
+     * Gets the value of the autoApplyRecommendationsStatus property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link ArrayOfAutoApplyRecommendationsInfo }
+     *     
+     */
+    public ArrayOfAutoApplyRecommendationsInfo getAutoApplyRecommendationsStatus() {
+        return autoApplyRecommendationsStatus;
+    }
+
+    /**
+     * Sets the value of the autoApplyRecommendationsStatus property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link ArrayOfAutoApplyRecommendationsInfo }
+     *     
+     */
+    public void setAutoApplyRecommendationsStatus(ArrayOfAutoApplyRecommendationsInfo value) {
+        this.autoApplyRecommendationsStatus = value;
+    }
+
+}

--- a/proxies/com/microsoft/bingads/v13/adinsight/GetPerformanceInsightsDetailDataByAccountIdRequest.java
+++ b/proxies/com/microsoft/bingads/v13/adinsight/GetPerformanceInsightsDetailDataByAccountIdRequest.java
@@ -1,0 +1,122 @@
+
+package com.microsoft.bingads.v13.adinsight;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlSchemaType;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java class for anonymous complex type.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ * 
+ * <pre>
+ * &lt;complexType>
+ *   &lt;complexContent>
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       &lt;sequence>
+ *         &lt;element name="EntityType" type="{https://bingads.microsoft.com/AdInsight/v13}EntityType" minOccurs="0"/>
+ *         &lt;element name="StartDate" type="{https://bingads.microsoft.com/AdInsight/v13}DayMonthAndYear" minOccurs="0"/>
+ *         &lt;element name="EndDate" type="{https://bingads.microsoft.com/AdInsight/v13}DayMonthAndYear" minOccurs="0"/>
+ *       &lt;/sequence>
+ *     &lt;/restriction>
+ *   &lt;/complexContent>
+ * &lt;/complexType>
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "entityType",
+    "startDate",
+    "endDate"
+})
+@XmlRootElement(name = "GetPerformanceInsightsDetailDataByAccountIdRequest")
+public class GetPerformanceInsightsDetailDataByAccountIdRequest {
+
+    @XmlElement(name = "EntityType")
+    @XmlSchemaType(name = "string")
+    protected EntityType entityType;
+    @XmlElement(name = "StartDate", nillable = true)
+    protected DayMonthAndYear startDate;
+    @XmlElement(name = "EndDate", nillable = true)
+    protected DayMonthAndYear endDate;
+
+    /**
+     * Gets the value of the entityType property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link EntityType }
+     *     
+     */
+    public EntityType getEntityType() {
+        return entityType;
+    }
+
+    /**
+     * Sets the value of the entityType property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link EntityType }
+     *     
+     */
+    public void setEntityType(EntityType value) {
+        this.entityType = value;
+    }
+
+    /**
+     * Gets the value of the startDate property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link DayMonthAndYear }
+     *     
+     */
+    public DayMonthAndYear getStartDate() {
+        return startDate;
+    }
+
+    /**
+     * Sets the value of the startDate property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link DayMonthAndYear }
+     *     
+     */
+    public void setStartDate(DayMonthAndYear value) {
+        this.startDate = value;
+    }
+
+    /**
+     * Gets the value of the endDate property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link DayMonthAndYear }
+     *     
+     */
+    public DayMonthAndYear getEndDate() {
+        return endDate;
+    }
+
+    /**
+     * Sets the value of the endDate property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link DayMonthAndYear }
+     *     
+     */
+    public void setEndDate(DayMonthAndYear value) {
+        this.endDate = value;
+    }
+
+}

--- a/proxies/com/microsoft/bingads/v13/adinsight/GetPerformanceInsightsDetailDataByAccountIdResponse.java
+++ b/proxies/com/microsoft/bingads/v13/adinsight/GetPerformanceInsightsDetailDataByAccountIdResponse.java
@@ -1,0 +1,64 @@
+
+package com.microsoft.bingads.v13.adinsight;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java class for anonymous complex type.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ * 
+ * <pre>
+ * &lt;complexType>
+ *   &lt;complexContent>
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       &lt;sequence>
+ *         &lt;element name="Result" type="{https://bingads.microsoft.com/AdInsight/v13}ArrayOfPerformanceInsightsDetail" minOccurs="0"/>
+ *       &lt;/sequence>
+ *     &lt;/restriction>
+ *   &lt;/complexContent>
+ * &lt;/complexType>
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "result"
+})
+@XmlRootElement(name = "GetPerformanceInsightsDetailDataByAccountIdResponse")
+public class GetPerformanceInsightsDetailDataByAccountIdResponse {
+
+    @XmlElement(name = "Result", nillable = true)
+    protected ArrayOfPerformanceInsightsDetail result;
+
+    /**
+     * Gets the value of the result property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link ArrayOfPerformanceInsightsDetail }
+     *     
+     */
+    public ArrayOfPerformanceInsightsDetail getResult() {
+        return result;
+    }
+
+    /**
+     * Sets the value of the result property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link ArrayOfPerformanceInsightsDetail }
+     *     
+     */
+    public void setResult(ArrayOfPerformanceInsightsDetail value) {
+        this.result = value;
+    }
+
+}

--- a/proxies/com/microsoft/bingads/v13/adinsight/IAdInsightService.java
+++ b/proxies/com/microsoft/bingads/v13/adinsight/IAdInsightService.java
@@ -56,8 +56,8 @@ public interface IAdInsightService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.adinsight.GetBidOpportunitiesResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFaultDetail_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetBidOpportunities", action = "GetBidOpportunities")
     @WebResult(name = "GetBidOpportunitiesResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
@@ -97,8 +97,8 @@ public interface IAdInsightService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.adinsight.GetBudgetOpportunitiesResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFaultDetail_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetBudgetOpportunities", action = "GetBudgetOpportunities")
     @WebResult(name = "GetBudgetOpportunitiesResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
@@ -220,8 +220,8 @@ public interface IAdInsightService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.adinsight.GetEstimatedPositionByKeywordIdsResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFaultDetail_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetEstimatedPositionByKeywordIds", action = "GetEstimatedPositionByKeywordIds")
     @WebResult(name = "GetEstimatedPositionByKeywordIdsResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
@@ -343,8 +343,8 @@ public interface IAdInsightService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.adinsight.GetBidLandscapeByAdGroupIdsResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFaultDetail_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetBidLandscapeByAdGroupIds", action = "GetBidLandscapeByAdGroupIds")
     @WebResult(name = "GetBidLandscapeByAdGroupIdsResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
@@ -425,8 +425,8 @@ public interface IAdInsightService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.adinsight.GetHistoricalKeywordPerformanceResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFaultDetail_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetHistoricalKeywordPerformance", action = "GetHistoricalKeywordPerformance")
     @WebResult(name = "GetHistoricalKeywordPerformanceResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
@@ -589,8 +589,8 @@ public interface IAdInsightService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.adinsight.GetKeywordLocationsResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFaultDetail_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetKeywordLocations", action = "GetKeywordLocations")
     @WebResult(name = "GetKeywordLocationsResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
@@ -671,8 +671,8 @@ public interface IAdInsightService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.adinsight.SuggestKeywordsFromExistingKeywordsResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFaultDetail_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "SuggestKeywordsFromExistingKeywords", action = "SuggestKeywordsFromExistingKeywords")
     @WebResult(name = "SuggestKeywordsFromExistingKeywordsResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
@@ -712,8 +712,8 @@ public interface IAdInsightService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.adinsight.GetAuctionInsightDataResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFaultDetail_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetAuctionInsightData", action = "GetAuctionInsightData")
     @WebResult(name = "GetAuctionInsightDataResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
@@ -753,8 +753,8 @@ public interface IAdInsightService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.adinsight.GetDomainCategoriesResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFaultDetail_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetDomainCategories", action = "GetDomainCategories")
     @WebResult(name = "GetDomainCategoriesResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
@@ -794,8 +794,8 @@ public interface IAdInsightService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.adinsight.PutMetricDataResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFaultDetail_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "PutMetricData", action = "PutMetricData")
     @WebResult(name = "PutMetricDataResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
@@ -835,8 +835,8 @@ public interface IAdInsightService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.adinsight.GetKeywordIdeaCategoriesResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFaultDetail_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetKeywordIdeaCategories", action = "GetKeywordIdeaCategories")
     @WebResult(name = "GetKeywordIdeaCategoriesResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
@@ -917,14 +917,137 @@ public interface IAdInsightService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.adinsight.GetKeywordTrafficEstimatesResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFaultDetail_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetKeywordTrafficEstimates", action = "GetKeywordTrafficEstimates")
     @WebResult(name = "GetKeywordTrafficEstimatesResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
     public GetKeywordTrafficEstimatesResponse getKeywordTrafficEstimates(
         @WebParam(name = "GetKeywordTrafficEstimatesRequest", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
         GetKeywordTrafficEstimatesRequest parameters)
+        throws AdApiFaultDetail_Exception, ApiFaultDetail_Exception
+    ;
+
+    /**
+     * 
+     * @param parameters
+     * @return
+     *     returns javax.xml.ws.Response<com.microsoft.bingads.v13.adinsight.GetAutoApplyOptInStatusResponse>
+     */
+    @WebMethod(operationName = "GetAutoApplyOptInStatus", action = "GetAutoApplyOptInStatus")
+    public Response<GetAutoApplyOptInStatusResponse> getAutoApplyOptInStatusAsync(
+        @WebParam(name = "GetAutoApplyOptInStatusRequest", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
+        GetAutoApplyOptInStatusRequest parameters);
+
+    /**
+     * 
+     * @param asyncHandler
+     * @param parameters
+     * @return
+     *     returns java.util.concurrent.Future<? extends java.lang.Object>
+     */
+    @WebMethod(operationName = "GetAutoApplyOptInStatus", action = "GetAutoApplyOptInStatus")
+    public Future<?> getAutoApplyOptInStatusAsync(
+        @WebParam(name = "GetAutoApplyOptInStatusRequest", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
+        GetAutoApplyOptInStatusRequest parameters,
+        @WebParam(name = "GetAutoApplyOptInStatusResponse", targetNamespace = "", partName = "asyncHandler")
+        AsyncHandler<GetAutoApplyOptInStatusResponse> asyncHandler);
+
+    /**
+     * 
+     * @param parameters
+     * @return
+     *     returns com.microsoft.bingads.v13.adinsight.GetAutoApplyOptInStatusResponse
+     * @throws ApiFaultDetail_Exception
+     * @throws AdApiFaultDetail_Exception
+     */
+    @WebMethod(operationName = "GetAutoApplyOptInStatus", action = "GetAutoApplyOptInStatus")
+    @WebResult(name = "GetAutoApplyOptInStatusResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
+    public GetAutoApplyOptInStatusResponse getAutoApplyOptInStatus(
+        @WebParam(name = "GetAutoApplyOptInStatusRequest", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
+        GetAutoApplyOptInStatusRequest parameters)
+        throws AdApiFaultDetail_Exception, ApiFaultDetail_Exception
+    ;
+
+    /**
+     * 
+     * @param parameters
+     * @return
+     *     returns javax.xml.ws.Response<com.microsoft.bingads.v13.adinsight.SetAutoApplyOptInStatusResponse>
+     */
+    @WebMethod(operationName = "SetAutoApplyOptInStatus", action = "SetAutoApplyOptInStatus")
+    public Response<SetAutoApplyOptInStatusResponse> setAutoApplyOptInStatusAsync(
+        @WebParam(name = "SetAutoApplyOptInStatusRequest", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
+        SetAutoApplyOptInStatusRequest parameters);
+
+    /**
+     * 
+     * @param asyncHandler
+     * @param parameters
+     * @return
+     *     returns java.util.concurrent.Future<? extends java.lang.Object>
+     */
+    @WebMethod(operationName = "SetAutoApplyOptInStatus", action = "SetAutoApplyOptInStatus")
+    public Future<?> setAutoApplyOptInStatusAsync(
+        @WebParam(name = "SetAutoApplyOptInStatusRequest", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
+        SetAutoApplyOptInStatusRequest parameters,
+        @WebParam(name = "SetAutoApplyOptInStatusResponse", targetNamespace = "", partName = "asyncHandler")
+        AsyncHandler<SetAutoApplyOptInStatusResponse> asyncHandler);
+
+    /**
+     * 
+     * @param parameters
+     * @return
+     *     returns com.microsoft.bingads.v13.adinsight.SetAutoApplyOptInStatusResponse
+     * @throws ApiFaultDetail_Exception
+     * @throws AdApiFaultDetail_Exception
+     */
+    @WebMethod(operationName = "SetAutoApplyOptInStatus", action = "SetAutoApplyOptInStatus")
+    @WebResult(name = "SetAutoApplyOptInStatusResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
+    public SetAutoApplyOptInStatusResponse setAutoApplyOptInStatus(
+        @WebParam(name = "SetAutoApplyOptInStatusRequest", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
+        SetAutoApplyOptInStatusRequest parameters)
+        throws AdApiFaultDetail_Exception, ApiFaultDetail_Exception
+    ;
+
+    /**
+     * 
+     * @param parameters
+     * @return
+     *     returns javax.xml.ws.Response<com.microsoft.bingads.v13.adinsight.GetPerformanceInsightsDetailDataByAccountIdResponse>
+     */
+    @WebMethod(operationName = "GetPerformanceInsightsDetailDataByAccountId", action = "GetPerformanceInsightsDetailDataByAccountId")
+    public Response<GetPerformanceInsightsDetailDataByAccountIdResponse> getPerformanceInsightsDetailDataByAccountIdAsync(
+        @WebParam(name = "GetPerformanceInsightsDetailDataByAccountIdRequest", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
+        GetPerformanceInsightsDetailDataByAccountIdRequest parameters);
+
+    /**
+     * 
+     * @param asyncHandler
+     * @param parameters
+     * @return
+     *     returns java.util.concurrent.Future<? extends java.lang.Object>
+     */
+    @WebMethod(operationName = "GetPerformanceInsightsDetailDataByAccountId", action = "GetPerformanceInsightsDetailDataByAccountId")
+    public Future<?> getPerformanceInsightsDetailDataByAccountIdAsync(
+        @WebParam(name = "GetPerformanceInsightsDetailDataByAccountIdRequest", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
+        GetPerformanceInsightsDetailDataByAccountIdRequest parameters,
+        @WebParam(name = "GetPerformanceInsightsDetailDataByAccountIdResponse", targetNamespace = "", partName = "asyncHandler")
+        AsyncHandler<GetPerformanceInsightsDetailDataByAccountIdResponse> asyncHandler);
+
+    /**
+     * 
+     * @param parameters
+     * @return
+     *     returns com.microsoft.bingads.v13.adinsight.GetPerformanceInsightsDetailDataByAccountIdResponse
+     * @throws ApiFaultDetail_Exception
+     * @throws AdApiFaultDetail_Exception
+     */
+    @WebMethod(operationName = "GetPerformanceInsightsDetailDataByAccountId", action = "GetPerformanceInsightsDetailDataByAccountId")
+    @WebResult(name = "GetPerformanceInsightsDetailDataByAccountIdResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
+    public GetPerformanceInsightsDetailDataByAccountIdResponse getPerformanceInsightsDetailDataByAccountId(
+        @WebParam(name = "GetPerformanceInsightsDetailDataByAccountIdRequest", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
+        GetPerformanceInsightsDetailDataByAccountIdRequest parameters)
         throws AdApiFaultDetail_Exception, ApiFaultDetail_Exception
     ;
 

--- a/proxies/com/microsoft/bingads/v13/adinsight/KPIType.java
+++ b/proxies/com/microsoft/bingads/v13/adinsight/KPIType.java
@@ -1,0 +1,57 @@
+
+package com.microsoft.bingads.v13.adinsight;
+
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java class for KPIType.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>
+ * <pre>
+ * &lt;simpleType name="KPIType">
+ *   &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string">
+ *     &lt;enumeration value="Impression"/>
+ *     &lt;enumeration value="Click"/>
+ *     &lt;enumeration value="Spend"/>
+ *     &lt;enumeration value="Conversion"/>
+ *   &lt;/restriction>
+ * &lt;/simpleType>
+ * </pre>
+ * 
+ */
+@XmlType(name = "KPIType")
+@XmlEnum
+public enum KPIType {
+
+    @XmlEnumValue("Impression")
+    IMPRESSION("Impression"),
+    @XmlEnumValue("Click")
+    CLICK("Click"),
+    @XmlEnumValue("Spend")
+    SPEND("Spend"),
+    @XmlEnumValue("Conversion")
+    CONVERSION("Conversion");
+    private final String value;
+
+    KPIType(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    public static KPIType fromValue(String v) {
+        for (KPIType c: KPIType.values()) {
+            if (c.value.equals(v)) {
+                return c;
+            }
+        }
+        throw new IllegalArgumentException(v);
+    }
+
+}

--- a/proxies/com/microsoft/bingads/v13/adinsight/ObjectFactory.java
+++ b/proxies/com/microsoft/bingads/v13/adinsight/ObjectFactory.java
@@ -28,132 +28,70 @@ import javax.xml.namespace.QName;
 @XmlRegistry
 public class ObjectFactory {
 
-    private final static QName _AdGroupBidLandscapeType_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "AdGroupBidLandscapeType");
-    private final static QName _KeywordKPI_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "KeywordKPI");
     private final static QName _QuerySearchParameter_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "QuerySearchParameter");
     private final static QName _ArrayOfKeywordDemographicResult_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfKeywordDemographicResult");
-    private final static QName _BudgetPointType_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "BudgetPointType");
-    private final static QName _ArrayOfBidLandscapePoint_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfBidLandscapePoint");
     private final static QName _Duration_QNAME = new QName("http://schemas.microsoft.com/2003/10/Serialization/", "duration");
     private final static QName _ArrayOfAuctionInsightEntry_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfAuctionInsightEntry");
     private final static QName _ArrayOfDomainCategory_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfDomainCategory");
-    private final static QName _ArrayOfOperationError_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfOperationError");
-    private final static QName _AdGroupEstimate_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "AdGroupEstimate");
-    private final static QName _ArrayOfCriterion_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfCriterion");
-    private final static QName _ArrayOfBidOpportunity_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfBidOpportunity");
     private final static QName _Password_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "Password");
     private final static QName _CompetitionSearchParameter_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "CompetitionSearchParameter");
-    private final static QName _ArrayOfAdApiError_QNAME = new QName("https://adapi.microsoft.com", "ArrayOfAdApiError");
     private final static QName _BroadMatchKeywordOpportunity_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "BroadMatchKeywordOpportunity");
-    private final static QName _BudgetOpportunity_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "BudgetOpportunity");
-    private final static QName _ArrayOfKeywordAndMatchType_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfKeywordAndMatchType");
-    private final static QName _KeywordDemographic_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "KeywordDemographic");
     private final static QName _Criterion_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "Criterion");
-    private final static QName _ArrayOfHistoricalSearchCountPeriodic_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfHistoricalSearchCountPeriodic");
-    private final static QName _TrafficEstimate_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "TrafficEstimate");
     private final static QName _CustomerAccountId_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "CustomerAccountId");
     private final static QName _Opportunity_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "Opportunity");
     private final static QName _String_QNAME = new QName("http://schemas.microsoft.com/2003/10/Serialization/", "string");
-    private final static QName _KeywordIdEstimatedPosition_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "KeywordIdEstimatedPosition");
-    private final static QName _NetworkType_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "NetworkType");
-    private final static QName _NetworkSearchParameter_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "NetworkSearchParameter");
     private final static QName _ArrayOfCompetitionLevel_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfCompetitionLevel");
     private final static QName _UnsignedInt_QNAME = new QName("http://schemas.microsoft.com/2003/10/Serialization/", "unsignedInt");
-    private final static QName _SearchCountsByAttributes_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "SearchCountsByAttributes");
     private final static QName _Short_QNAME = new QName("http://schemas.microsoft.com/2003/10/Serialization/", "short");
-    private final static QName _KeywordSearchCount_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "KeywordSearchCount");
+    private final static QName _AutoApplyRecommendationsInfo_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "AutoApplyRecommendationsInfo");
     private final static QName _ArrayOfKeywordLocationResult_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfKeywordLocationResult");
-    private final static QName _ArrayOfKeywordOpportunity_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfKeywordOpportunity");
-    private final static QName _ArrayOfKeywordEstimatedBid_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfKeywordEstimatedBid");
-    private final static QName _Boolean_QNAME = new QName("http://schemas.microsoft.com/2003/10/Serialization/", "boolean");
     private final static QName _UserName_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "UserName");
-    private final static QName _KeywordEstimatedBid_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "KeywordEstimatedBid");
-    private final static QName _ArrayOfBatchError_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfBatchError");
     private final static QName _TimeInterval_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "TimeInterval");
     private final static QName _ArrayOfAdGroupEstimate_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfAdGroupEstimate");
-    private final static QName _NegativeKeyword_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "NegativeKeyword");
-    private final static QName _ArrayOfKeywordEstimatedPosition_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfKeywordEstimatedPosition");
     private final static QName _ArrayOfCampaignEstimator_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfCampaignEstimator");
     private final static QName _TargetAdPosition_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "TargetAdPosition");
-    private final static QName _ApiFaultDetail_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ApiFaultDetail");
-    private final static QName _Int_QNAME = new QName("http://schemas.microsoft.com/2003/10/Serialization/", "int");
+    private final static QName _KPIType_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "KPIType");
     private final static QName _KeywordEstimate_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "KeywordEstimate");
-    private final static QName _MetricData_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "MetricData");
-    private final static QName _ArrayOfKeywordIdEstimatedPosition_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfKeywordIdEstimatedPosition");
-    private final static QName _ArrayOfLanguageCriterion_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfLanguageCriterion");
     private final static QName _QName_QNAME = new QName("http://schemas.microsoft.com/2003/10/Serialization/", "QName");
-    private final static QName _ArrayOfKeywordIdeaCategory_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfKeywordIdeaCategory");
     private final static QName _AdGroupBidLandscapeInput_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "AdGroupBidLandscapeInput");
+    private final static QName _PerformanceInsightsMessageParameter_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "PerformanceInsightsMessageParameter");
     private final static QName _ArrayOfAdGroupEstimator_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfAdGroupEstimator");
-    private final static QName _ArrayOfBroadMatchSearchQueryKPI_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfBroadMatchSearchQueryKPI");
-    private final static QName _UnsignedByte_QNAME = new QName("http://schemas.microsoft.com/2003/10/Serialization/", "unsignedByte");
     private final static QName _HistoricalSearchCountPeriodic_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "HistoricalSearchCountPeriodic");
-    private final static QName _ArrayOfMatchType_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfMatchType");
-    private final static QName _ArrayOfKeywordKPI_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfKeywordKPI");
-    private final static QName _ArrayOfAuctionInsightKpi_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfAuctionInsightKpi");
+    private final static QName _ArrayOfEntityDetail_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfEntityDetail");
     private final static QName _IdeaTextSearchParameter_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "IdeaTextSearchParameter");
     private final static QName _ArrayOfKeywordSearchCount_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfKeywordSearchCount");
     private final static QName _SourceType_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "SourceType");
     private final static QName _ArrayOfNegativeKeyword_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfNegativeKeyword");
-    private final static QName _KeywordIdEstimatedBid_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "KeywordIdEstimatedBid");
-    private final static QName _ApplicationToken_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ApplicationToken");
-    private final static QName _Float_QNAME = new QName("http://schemas.microsoft.com/2003/10/Serialization/", "float");
-    private final static QName _KeywordIdea_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "KeywordIdea");
-    private final static QName _ArrayOfMetricData_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfMetricData");
     private final static QName _ArrayOfKeywordLocation_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfKeywordLocation");
-    private final static QName _KeywordLocation_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "KeywordLocation");
-    private final static QName _AdApiError_QNAME = new QName("https://adapi.microsoft.com", "AdApiError");
     private final static QName _ArrayOfKeywordHistoricalPerformance_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfKeywordHistoricalPerformance");
     private final static QName _ArrayOfCampaignEstimate_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfCampaignEstimate");
-    private final static QName _LocationCriterion_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "LocationCriterion");
     private final static QName _AnyType_QNAME = new QName("http://schemas.microsoft.com/2003/10/Serialization/", "anyType");
     private final static QName _ArrayOfKeywordDemographic_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfKeywordDemographic");
     private final static QName _UrlSearchParameter_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "UrlSearchParameter");
     private final static QName _KeywordLocationResult_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "KeywordLocationResult");
-    private final static QName _LanguageSearchParameter_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "LanguageSearchParameter");
     private final static QName _Guid_QNAME = new QName("http://schemas.microsoft.com/2003/10/Serialization/", "guid");
     private final static QName _Decimal_QNAME = new QName("http://schemas.microsoft.com/2003/10/Serialization/", "decimal");
     private final static QName _ArrayOfKeywordCategoryResult_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfKeywordCategoryResult");
     private final static QName _AuctionInsightKpi_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "AuctionInsightKpi");
     private final static QName _ArrayOfKeywordIdea_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfKeywordIdea");
-    private final static QName _BidOpportunityType_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "BidOpportunityType");
-    private final static QName _Base64Binary_QNAME = new QName("http://schemas.microsoft.com/2003/10/Serialization/", "base64Binary");
-    private final static QName _CampaignEstimator_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "CampaignEstimator");
-    private final static QName _ArrayOfEstimatedPositionAndTraffic_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfEstimatedPositionAndTraffic");
-    private final static QName _EntityType_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "EntityType");
     private final static QName _LanguageCriterion_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "LanguageCriterion");
     private final static QName _KeywordOpportunity_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "KeywordOpportunity");
-    private final static QName _ArrayOfAdGroupBidLandscapeInput_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfAdGroupBidLandscapeInput");
-    private final static QName _ExcludeAccountKeywordsSearchParameter_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ExcludeAccountKeywordsSearchParameter");
     private final static QName _AuctionInsightResult_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "AuctionInsightResult");
     private final static QName _AuctionInsightEntry_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "AuctionInsightEntry");
-    private final static QName _AdPosition_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "AdPosition");
     private final static QName _ArrayOflong_QNAME = new QName("http://schemas.microsoft.com/2003/10/Serialization/Arrays", "ArrayOflong");
     private final static QName _ArrayOfKeywordIdeaAttribute_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfKeywordIdeaAttribute");
+    private final static QName _ArrayOfPerformanceInsightsMessageParameter_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfPerformanceInsightsMessageParameter");
+    private final static QName _PerformanceInsightsUrlCategory_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "PerformanceInsightsUrlCategory");
     private final static QName _ArrayOfstring_QNAME = new QName("http://schemas.microsoft.com/2003/10/Serialization/Arrays", "ArrayOfstring");
     private final static QName _ArrayOfAdGroupBidLandscape_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfAdGroupBidLandscape");
-    private final static QName _ArrayOfSearchCountsByAttributes_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfSearchCountsByAttributes");
     private final static QName _Long_QNAME = new QName("http://schemas.microsoft.com/2003/10/Serialization/", "long");
-    private final static QName _SearchParameter_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "SearchParameter");
-    private final static QName _SearchVolumeSearchParameter_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "SearchVolumeSearchParameter");
-    private final static QName _AuctionInsightKpiAdditionalField_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "AuctionInsightKpiAdditionalField");
-    private final static QName _KeywordEstimatedPosition_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "KeywordEstimatedPosition");
-    private final static QName _DateTime_QNAME = new QName("http://schemas.microsoft.com/2003/10/Serialization/", "dateTime");
+    private final static QName _TextParameter_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "TextParameter");
     private final static QName _CampaignEstimate_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "CampaignEstimate");
-    private final static QName _ArrayOfLocationCriterion_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfLocationCriterion");
-    private final static QName _KeywordEstimator_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "KeywordEstimator");
-    private final static QName _AdGroupEstimator_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "AdGroupEstimator");
-    private final static QName _Char_QNAME = new QName("http://schemas.microsoft.com/2003/10/Serialization/", "char");
-    private final static QName _DomainCategory_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "DomainCategory");
     private final static QName _OperationError_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "OperationError");
     private final static QName _DateRangeSearchParameter_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "DateRangeSearchParameter");
-    private final static QName _SuggestedBidSearchParameter_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "SuggestedBidSearchParameter");
     private final static QName _AuctionSegment_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "AuctionSegment");
-    private final static QName _Keyword_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "Keyword");
     private final static QName _BatchError_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "BatchError");
-    private final static QName _LocationSearchParameter_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "LocationSearchParameter");
-    private final static QName _KeywordDemographicResult_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "KeywordDemographicResult");
-    private final static QName _ArrayOfKeywordSuggestion_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfKeywordSuggestion");
+    private final static QName _PerformanceInsightsEntityType_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "PerformanceInsightsEntityType");
     private final static QName _DeveloperToken_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "DeveloperToken");
     private final static QName _NetworkCriterion_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "NetworkCriterion");
     private final static QName _AdGroupBidLandscape_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "AdGroupBidLandscape");
@@ -161,40 +99,26 @@ public class ObjectFactory {
     private final static QName _MatchType_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "MatchType");
     private final static QName _ArrayOfKeywordEstimator_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfKeywordEstimator");
     private final static QName _CompetitionLevel_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "CompetitionLevel");
-    private final static QName _DayMonthAndYear_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "DayMonthAndYear");
-    private final static QName _UnsignedLong_QNAME = new QName("http://schemas.microsoft.com/2003/10/Serialization/", "unsignedLong");
-    private final static QName _ArrayOfEstimatedBidAndTraffic_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfEstimatedBidAndTraffic");
-    private final static QName _UnsignedShort_QNAME = new QName("http://schemas.microsoft.com/2003/10/Serialization/", "unsignedShort");
     private final static QName _KeywordBidLandscape_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "KeywordBidLandscape");
     private final static QName _ImpressionShareSearchParameter_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ImpressionShareSearchParameter");
     private final static QName _ArrayOfKeywordBidLandscape_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfKeywordBidLandscape");
     private final static QName _EstimatedPositionAndTraffic_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "EstimatedPositionAndTraffic");
     private final static QName _AuthenticationToken_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "AuthenticationToken");
     private final static QName _DeviceCriterion_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "DeviceCriterion");
-    private final static QName _BidOpportunity_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "BidOpportunity");
-    private final static QName _ArrayOfKeywordIdEstimatedBid_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfKeywordIdEstimatedBid");
     private final static QName _ArrayOfKeywordCategory_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfKeywordCategory");
     private final static QName _ArrayOfKeywordAndConfidence_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfKeywordAndConfidence");
     private final static QName _ArrayOfSearchParameter_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfSearchParameter");
     private final static QName _EstimatedBidAndTraffic_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "EstimatedBidAndTraffic");
     private final static QName _CurrencyCode_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "CurrencyCode");
-    private final static QName _ArrayOfBudgetOpportunity_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfBudgetOpportunity");
-    private final static QName _BroadMatchSearchQueryKPI_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "BroadMatchSearchQueryKPI");
-    private final static QName _BudgetPoint_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "BudgetPoint");
-    private final static QName _KeywordIdeaCategory_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "KeywordIdeaCategory");
+    private final static QName _EntityParameter_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "EntityParameter");
     private final static QName _ArrayOfBudgetPoint_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfBudgetPoint");
-    private final static QName _CustomerId_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "CustomerId");
     private final static QName _KeywordAndConfidence_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "KeywordAndConfidence");
-    private final static QName _AdApiFaultDetail_QNAME = new QName("https://adapi.microsoft.com", "AdApiFaultDetail");
     private final static QName _TrackingId_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "TrackingId");
-    private final static QName _KeywordOpportunityType_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "KeywordOpportunityType");
-    private final static QName _KeywordHistoricalPerformance_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "KeywordHistoricalPerformance");
-    private final static QName _ApplicationFault_QNAME = new QName("https://adapi.microsoft.com", "ApplicationFault");
-    private final static QName _BidLandscapePoint_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "BidLandscapePoint");
+    private final static QName _PerformanceInsightsMessageTemplateId_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "PerformanceInsightsMessageTemplateId");
     private final static QName _KeywordCategoryResult_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "KeywordCategoryResult");
-    private final static QName _KeywordCategory_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "KeywordCategory");
     private final static QName _KeywordSuggestion_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "KeywordSuggestion");
     private final static QName _DeviceSearchParameter_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "DeviceSearchParameter");
+    private final static QName _PerformanceInsightsDetail_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "PerformanceInsightsDetail");
     private final static QName _ArrayOfKeywordEstimate_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfKeywordEstimate");
     private final static QName _AnyURI_QNAME = new QName("http://schemas.microsoft.com/2003/10/Serialization/", "anyURI");
     private final static QName _AuctionSegmentSearchParameter_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "AuctionSegmentSearchParameter");
@@ -202,9 +126,104 @@ public class ObjectFactory {
     private final static QName _KeywordAndMatchType_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "KeywordAndMatchType");
     private final static QName _BudgetLimitType_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "BudgetLimitType");
     private final static QName _CategorySearchParameter_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "CategorySearchParameter");
+    private final static QName _ArrayOfAuctionSegment_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfAuctionSegment");
+    private final static QName _AdGroupBidLandscapeType_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "AdGroupBidLandscapeType");
+    private final static QName _KeywordKPI_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "KeywordKPI");
+    private final static QName _ArrayOfPerformanceInsightsDetail_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfPerformanceInsightsDetail");
+    private final static QName _BudgetPointType_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "BudgetPointType");
+    private final static QName _ArrayOfBidLandscapePoint_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfBidLandscapePoint");
+    private final static QName _ArrayOfOperationError_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfOperationError");
+    private final static QName _AdGroupEstimate_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "AdGroupEstimate");
+    private final static QName _ArrayOfCriterion_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfCriterion");
+    private final static QName _PerformanceInsightsMessage_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "PerformanceInsightsMessage");
+    private final static QName _ArrayOfBidOpportunity_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfBidOpportunity");
+    private final static QName _UrlParameter_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "UrlParameter");
+    private final static QName _ArrayOfAdApiError_QNAME = new QName("https://adapi.microsoft.com", "ArrayOfAdApiError");
+    private final static QName _BudgetOpportunity_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "BudgetOpportunity");
+    private final static QName _ArrayOfKeywordAndMatchType_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfKeywordAndMatchType");
+    private final static QName _KeywordDemographic_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "KeywordDemographic");
+    private final static QName _ArrayOfHistoricalSearchCountPeriodic_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfHistoricalSearchCountPeriodic");
+    private final static QName _TrafficEstimate_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "TrafficEstimate");
+    private final static QName _KeywordIdEstimatedPosition_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "KeywordIdEstimatedPosition");
+    private final static QName _NetworkType_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "NetworkType");
+    private final static QName _NetworkSearchParameter_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "NetworkSearchParameter");
+    private final static QName _SearchCountsByAttributes_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "SearchCountsByAttributes");
+    private final static QName _KeywordSearchCount_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "KeywordSearchCount");
+    private final static QName _ArrayOfKeywordOpportunity_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfKeywordOpportunity");
+    private final static QName _ArrayOfKeywordEstimatedBid_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfKeywordEstimatedBid");
+    private final static QName _Boolean_QNAME = new QName("http://schemas.microsoft.com/2003/10/Serialization/", "boolean");
+    private final static QName _KeywordEstimatedBid_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "KeywordEstimatedBid");
+    private final static QName _ArrayOfBatchError_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfBatchError");
+    private final static QName _NegativeKeyword_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "NegativeKeyword");
+    private final static QName _ArrayOfKeywordEstimatedPosition_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfKeywordEstimatedPosition");
+    private final static QName _ApiFaultDetail_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ApiFaultDetail");
+    private final static QName _Int_QNAME = new QName("http://schemas.microsoft.com/2003/10/Serialization/", "int");
+    private final static QName _MetricData_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "MetricData");
+    private final static QName _ArrayOfPerformanceInsightsMessage_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfPerformanceInsightsMessage");
+    private final static QName _ArrayOfKeywordIdEstimatedPosition_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfKeywordIdEstimatedPosition");
+    private final static QName _ArrayOfLanguageCriterion_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfLanguageCriterion");
+    private final static QName _ArrayOfKeywordIdeaCategory_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfKeywordIdeaCategory");
+    private final static QName _ArrayOfBroadMatchSearchQueryKPI_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfBroadMatchSearchQueryKPI");
+    private final static QName _UnsignedByte_QNAME = new QName("http://schemas.microsoft.com/2003/10/Serialization/", "unsignedByte");
+    private final static QName _ArrayOfMatchType_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfMatchType");
+    private final static QName _ArrayOfKeywordKPI_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfKeywordKPI");
+    private final static QName _PerformanceInsightsUrlId_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "PerformanceInsightsUrlId");
+    private final static QName _ArrayOfAuctionInsightKpi_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfAuctionInsightKpi");
+    private final static QName _KeywordIdEstimatedBid_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "KeywordIdEstimatedBid");
+    private final static QName _ApplicationToken_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ApplicationToken");
+    private final static QName _Float_QNAME = new QName("http://schemas.microsoft.com/2003/10/Serialization/", "float");
+    private final static QName _KeywordIdea_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "KeywordIdea");
+    private final static QName _ArrayOfMetricData_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfMetricData");
+    private final static QName _KeywordLocation_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "KeywordLocation");
+    private final static QName _AdApiError_QNAME = new QName("https://adapi.microsoft.com", "AdApiError");
+    private final static QName _LocationCriterion_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "LocationCriterion");
+    private final static QName _LanguageSearchParameter_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "LanguageSearchParameter");
+    private final static QName _BidOpportunityType_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "BidOpportunityType");
+    private final static QName _Base64Binary_QNAME = new QName("http://schemas.microsoft.com/2003/10/Serialization/", "base64Binary");
+    private final static QName _CampaignEstimator_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "CampaignEstimator");
+    private final static QName _ArrayOfEstimatedPositionAndTraffic_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfEstimatedPositionAndTraffic");
+    private final static QName _EntityType_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "EntityType");
+    private final static QName _ArrayOfAdGroupBidLandscapeInput_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfAdGroupBidLandscapeInput");
+    private final static QName _ExcludeAccountKeywordsSearchParameter_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ExcludeAccountKeywordsSearchParameter");
+    private final static QName _AdPosition_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "AdPosition");
+    private final static QName _ArrayOfSearchCountsByAttributes_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfSearchCountsByAttributes");
+    private final static QName _SearchParameter_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "SearchParameter");
+    private final static QName _SearchVolumeSearchParameter_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "SearchVolumeSearchParameter");
+    private final static QName _AuctionInsightKpiAdditionalField_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "AuctionInsightKpiAdditionalField");
+    private final static QName _KeywordEstimatedPosition_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "KeywordEstimatedPosition");
+    private final static QName _DateTime_QNAME = new QName("http://schemas.microsoft.com/2003/10/Serialization/", "dateTime");
+    private final static QName _ArrayOfLocationCriterion_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfLocationCriterion");
+    private final static QName _KeywordEstimator_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "KeywordEstimator");
+    private final static QName _ArrayOfAutoApplyRecommendationsInfo_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfAutoApplyRecommendationsInfo");
+    private final static QName _AdGroupEstimator_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "AdGroupEstimator");
+    private final static QName _Char_QNAME = new QName("http://schemas.microsoft.com/2003/10/Serialization/", "char");
+    private final static QName _DomainCategory_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "DomainCategory");
+    private final static QName _SuggestedBidSearchParameter_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "SuggestedBidSearchParameter");
+    private final static QName _ParameterType_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ParameterType");
+    private final static QName _Keyword_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "Keyword");
+    private final static QName _LocationSearchParameter_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "LocationSearchParameter");
+    private final static QName _KeywordDemographicResult_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "KeywordDemographicResult");
+    private final static QName _ArrayOfKeywordSuggestion_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfKeywordSuggestion");
+    private final static QName _DayMonthAndYear_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "DayMonthAndYear");
+    private final static QName _UnsignedLong_QNAME = new QName("http://schemas.microsoft.com/2003/10/Serialization/", "unsignedLong");
+    private final static QName _ArrayOfEstimatedBidAndTraffic_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfEstimatedBidAndTraffic");
+    private final static QName _UnsignedShort_QNAME = new QName("http://schemas.microsoft.com/2003/10/Serialization/", "unsignedShort");
+    private final static QName _BidOpportunity_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "BidOpportunity");
+    private final static QName _ArrayOfKeywordIdEstimatedBid_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfKeywordIdEstimatedBid");
+    private final static QName _EntityDetail_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "EntityDetail");
+    private final static QName _ArrayOfBudgetOpportunity_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfBudgetOpportunity");
+    private final static QName _BroadMatchSearchQueryKPI_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "BroadMatchSearchQueryKPI");
+    private final static QName _BudgetPoint_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "BudgetPoint");
+    private final static QName _KeywordIdeaCategory_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "KeywordIdeaCategory");
+    private final static QName _CustomerId_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "CustomerId");
+    private final static QName _AdApiFaultDetail_QNAME = new QName("https://adapi.microsoft.com", "AdApiFaultDetail");
+    private final static QName _KeywordOpportunityType_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "KeywordOpportunityType");
+    private final static QName _KeywordHistoricalPerformance_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "KeywordHistoricalPerformance");
+    private final static QName _ApplicationFault_QNAME = new QName("https://adapi.microsoft.com", "ApplicationFault");
+    private final static QName _BidLandscapePoint_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "BidLandscapePoint");
+    private final static QName _KeywordCategory_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "KeywordCategory");
     private final static QName _Byte_QNAME = new QName("http://schemas.microsoft.com/2003/10/Serialization/", "byte");
     private final static QName _Double_QNAME = new QName("http://schemas.microsoft.com/2003/10/Serialization/", "double");
-    private final static QName _ArrayOfAuctionSegment_QNAME = new QName("https://bingads.microsoft.com/AdInsight/v13", "ArrayOfAuctionSegment");
 
     /**
      * Create a new ObjectFactory that can be used to create new instances of schema derived classes for package: com.microsoft.bingads.v13.adinsight
@@ -390,6 +409,14 @@ public class ObjectFactory {
     }
 
     /**
+     * Create an instance of {@link EntityParameter }
+     * 
+     */
+    public EntityParameter createEntityParameter() {
+        return new EntityParameter();
+    }
+
+    /**
      * Create an instance of {@link SuggestKeywordsForUrlResponse }
      * 
      */
@@ -550,6 +577,14 @@ public class ObjectFactory {
     }
 
     /**
+     * Create an instance of {@link PerformanceInsightsDetail }
+     * 
+     */
+    public PerformanceInsightsDetail createPerformanceInsightsDetail() {
+        return new PerformanceInsightsDetail();
+    }
+
+    /**
      * Create an instance of {@link GetEstimatedBidByKeywordIdsRequest }
      * 
      */
@@ -638,6 +673,14 @@ public class ObjectFactory {
     }
 
     /**
+     * Create an instance of {@link ArrayOfPerformanceInsightsMessageParameter }
+     * 
+     */
+    public ArrayOfPerformanceInsightsMessageParameter createArrayOfPerformanceInsightsMessageParameter() {
+        return new ArrayOfPerformanceInsightsMessageParameter();
+    }
+
+    /**
      * Create an instance of {@link GetHistoricalKeywordPerformanceResponse }
      * 
      */
@@ -654,11 +697,35 @@ public class ObjectFactory {
     }
 
     /**
+     * Create an instance of {@link TextParameter }
+     * 
+     */
+    public TextParameter createTextParameter() {
+        return new TextParameter();
+    }
+
+    /**
      * Create an instance of {@link ArrayOfAdGroupBidLandscape }
      * 
      */
     public ArrayOfAdGroupBidLandscape createArrayOfAdGroupBidLandscape() {
         return new ArrayOfAdGroupBidLandscape();
+    }
+
+    /**
+     * Create an instance of {@link GetPerformanceInsightsDetailDataByAccountIdRequest }
+     * 
+     */
+    public GetPerformanceInsightsDetailDataByAccountIdRequest createGetPerformanceInsightsDetailDataByAccountIdRequest() {
+        return new GetPerformanceInsightsDetailDataByAccountIdRequest();
+    }
+
+    /**
+     * Create an instance of {@link DayMonthAndYear }
+     * 
+     */
+    public DayMonthAndYear createDayMonthAndYear() {
+        return new DayMonthAndYear();
     }
 
     /**
@@ -758,6 +825,14 @@ public class ObjectFactory {
     }
 
     /**
+     * Create an instance of {@link ArrayOfEntityDetail }
+     * 
+     */
+    public ArrayOfEntityDetail createArrayOfEntityDetail() {
+        return new ArrayOfEntityDetail();
+    }
+
+    /**
      * Create an instance of {@link ArrayOfKeywordSearchCount }
      * 
      */
@@ -779,6 +854,14 @@ public class ObjectFactory {
      */
     public ArrayOfNegativeKeyword createArrayOfNegativeKeyword() {
         return new ArrayOfNegativeKeyword();
+    }
+
+    /**
+     * Create an instance of {@link PerformanceInsightsMessageParameter }
+     * 
+     */
+    public PerformanceInsightsMessageParameter createPerformanceInsightsMessageParameter() {
+        return new PerformanceInsightsMessageParameter();
     }
 
     /**
@@ -926,6 +1009,14 @@ public class ObjectFactory {
     }
 
     /**
+     * Create an instance of {@link GetAutoApplyOptInStatusRequest }
+     * 
+     */
+    public GetAutoApplyOptInStatusRequest createGetAutoApplyOptInStatusRequest() {
+        return new GetAutoApplyOptInStatusRequest();
+    }
+
+    /**
      * Create an instance of {@link ArrayOfAuctionInsightEntry }
      * 
      */
@@ -1054,11 +1145,11 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link DayMonthAndYear }
+     * Create an instance of {@link AutoApplyRecommendationsInfo }
      * 
      */
-    public DayMonthAndYear createDayMonthAndYear() {
-        return new DayMonthAndYear();
+    public AutoApplyRecommendationsInfo createAutoApplyRecommendationsInfo() {
+        return new AutoApplyRecommendationsInfo();
     }
 
     /**
@@ -1107,6 +1198,14 @@ public class ObjectFactory {
      */
     public BidOpportunity createBidOpportunity() {
         return new BidOpportunity();
+    }
+
+    /**
+     * Create an instance of {@link SetAutoApplyOptInStatusRequest }
+     * 
+     */
+    public SetAutoApplyOptInStatusRequest createSetAutoApplyOptInStatusRequest() {
+        return new SetAutoApplyOptInStatusRequest();
     }
 
     /**
@@ -1166,6 +1265,14 @@ public class ObjectFactory {
     }
 
     /**
+     * Create an instance of {@link EntityDetail }
+     * 
+     */
+    public EntityDetail createEntityDetail() {
+        return new EntityDetail();
+    }
+
+    /**
      * Create an instance of {@link BidLandscapePoint }
      * 
      */
@@ -1211,6 +1318,22 @@ public class ObjectFactory {
      */
     public GetDomainCategoriesResponse createGetDomainCategoriesResponse() {
         return new GetDomainCategoriesResponse();
+    }
+
+    /**
+     * Create an instance of {@link GetPerformanceInsightsDetailDataByAccountIdResponse }
+     * 
+     */
+    public GetPerformanceInsightsDetailDataByAccountIdResponse createGetPerformanceInsightsDetailDataByAccountIdResponse() {
+        return new GetPerformanceInsightsDetailDataByAccountIdResponse();
+    }
+
+    /**
+     * Create an instance of {@link ArrayOfPerformanceInsightsDetail }
+     * 
+     */
+    public ArrayOfPerformanceInsightsDetail createArrayOfPerformanceInsightsDetail() {
+        return new ArrayOfPerformanceInsightsDetail();
     }
 
     /**
@@ -1291,6 +1414,14 @@ public class ObjectFactory {
      */
     public LocationSearchParameter createLocationSearchParameter() {
         return new LocationSearchParameter();
+    }
+
+    /**
+     * Create an instance of {@link ArrayOfAutoApplyRecommendationsInfo }
+     * 
+     */
+    public ArrayOfAutoApplyRecommendationsInfo createArrayOfAutoApplyRecommendationsInfo() {
+        return new ArrayOfAutoApplyRecommendationsInfo();
     }
 
     /**
@@ -1502,6 +1633,22 @@ public class ObjectFactory {
     }
 
     /**
+     * Create an instance of {@link SetAutoApplyOptInStatusResponse }
+     * 
+     */
+    public SetAutoApplyOptInStatusResponse createSetAutoApplyOptInStatusResponse() {
+        return new SetAutoApplyOptInStatusResponse();
+    }
+
+    /**
+     * Create an instance of {@link ArrayOfBatchError }
+     * 
+     */
+    public ArrayOfBatchError createArrayOfBatchError() {
+        return new ArrayOfBatchError();
+    }
+
+    /**
      * Create an instance of {@link ArrayOfOperationError }
      * 
      */
@@ -1590,6 +1737,14 @@ public class ObjectFactory {
     }
 
     /**
+     * Create an instance of {@link UrlParameter }
+     * 
+     */
+    public UrlParameter createUrlParameter() {
+        return new UrlParameter();
+    }
+
+    /**
      * Create an instance of {@link GetKeywordTrafficEstimatesRequest }
      * 
      */
@@ -1598,11 +1753,11 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link ArrayOfBatchError }
+     * Create an instance of {@link PerformanceInsightsMessage }
      * 
      */
-    public ArrayOfBatchError createArrayOfBatchError() {
-        return new ArrayOfBatchError();
+    public PerformanceInsightsMessage createPerformanceInsightsMessage() {
+        return new PerformanceInsightsMessage();
     }
 
     /**
@@ -1619,6 +1774,14 @@ public class ObjectFactory {
      */
     public NegativeKeyword createNegativeKeyword() {
         return new NegativeKeyword();
+    }
+
+    /**
+     * Create an instance of {@link GetAutoApplyOptInStatusResponse }
+     * 
+     */
+    public GetAutoApplyOptInStatusResponse createGetAutoApplyOptInStatusResponse() {
+        return new GetAutoApplyOptInStatusResponse();
     }
 
     /**
@@ -1675,6 +1838,14 @@ public class ObjectFactory {
      */
     public ApiFaultDetail createApiFaultDetail() {
         return new ApiFaultDetail();
+    }
+
+    /**
+     * Create an instance of {@link ArrayOfPerformanceInsightsMessage }
+     * 
+     */
+    public ArrayOfPerformanceInsightsMessage createArrayOfPerformanceInsightsMessage() {
+        return new ArrayOfPerformanceInsightsMessage();
     }
 
     /**
@@ -1742,24 +1913,6 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AdGroupBidLandscapeType }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "AdGroupBidLandscapeType")
-    public JAXBElement<AdGroupBidLandscapeType> createAdGroupBidLandscapeType(AdGroupBidLandscapeType value) {
-        return new JAXBElement<AdGroupBidLandscapeType>(_AdGroupBidLandscapeType_QNAME, AdGroupBidLandscapeType.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link KeywordKPI }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "KeywordKPI")
-    public JAXBElement<KeywordKPI> createKeywordKPI(KeywordKPI value) {
-        return new JAXBElement<KeywordKPI>(_KeywordKPI_QNAME, KeywordKPI.class, null, value);
-    }
-
-    /**
      * Create an instance of {@link JAXBElement }{@code <}{@link QuerySearchParameter }{@code >}}
      * 
      */
@@ -1775,24 +1928,6 @@ public class ObjectFactory {
     @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfKeywordDemographicResult")
     public JAXBElement<ArrayOfKeywordDemographicResult> createArrayOfKeywordDemographicResult(ArrayOfKeywordDemographicResult value) {
         return new JAXBElement<ArrayOfKeywordDemographicResult>(_ArrayOfKeywordDemographicResult_QNAME, ArrayOfKeywordDemographicResult.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link BudgetPointType }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "BudgetPointType")
-    public JAXBElement<BudgetPointType> createBudgetPointType(BudgetPointType value) {
-        return new JAXBElement<BudgetPointType>(_BudgetPointType_QNAME, BudgetPointType.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfBidLandscapePoint }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfBidLandscapePoint")
-    public JAXBElement<ArrayOfBidLandscapePoint> createArrayOfBidLandscapePoint(ArrayOfBidLandscapePoint value) {
-        return new JAXBElement<ArrayOfBidLandscapePoint>(_ArrayOfBidLandscapePoint_QNAME, ArrayOfBidLandscapePoint.class, null, value);
     }
 
     /**
@@ -1823,42 +1958,6 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfOperationError }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfOperationError")
-    public JAXBElement<ArrayOfOperationError> createArrayOfOperationError(ArrayOfOperationError value) {
-        return new JAXBElement<ArrayOfOperationError>(_ArrayOfOperationError_QNAME, ArrayOfOperationError.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AdGroupEstimate }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "AdGroupEstimate")
-    public JAXBElement<AdGroupEstimate> createAdGroupEstimate(AdGroupEstimate value) {
-        return new JAXBElement<AdGroupEstimate>(_AdGroupEstimate_QNAME, AdGroupEstimate.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfCriterion }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfCriterion")
-    public JAXBElement<ArrayOfCriterion> createArrayOfCriterion(ArrayOfCriterion value) {
-        return new JAXBElement<ArrayOfCriterion>(_ArrayOfCriterion_QNAME, ArrayOfCriterion.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfBidOpportunity }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfBidOpportunity")
-    public JAXBElement<ArrayOfBidOpportunity> createArrayOfBidOpportunity(ArrayOfBidOpportunity value) {
-        return new JAXBElement<ArrayOfBidOpportunity>(_ArrayOfBidOpportunity_QNAME, ArrayOfBidOpportunity.class, null, value);
-    }
-
-    /**
      * Create an instance of {@link JAXBElement }{@code <}{@link String }{@code >}}
      * 
      */
@@ -1877,15 +1976,6 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfAdApiError }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://adapi.microsoft.com", name = "ArrayOfAdApiError")
-    public JAXBElement<ArrayOfAdApiError> createArrayOfAdApiError(ArrayOfAdApiError value) {
-        return new JAXBElement<ArrayOfAdApiError>(_ArrayOfAdApiError_QNAME, ArrayOfAdApiError.class, null, value);
-    }
-
-    /**
      * Create an instance of {@link JAXBElement }{@code <}{@link BroadMatchKeywordOpportunity }{@code >}}
      * 
      */
@@ -1895,57 +1985,12 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link BudgetOpportunity }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "BudgetOpportunity")
-    public JAXBElement<BudgetOpportunity> createBudgetOpportunity(BudgetOpportunity value) {
-        return new JAXBElement<BudgetOpportunity>(_BudgetOpportunity_QNAME, BudgetOpportunity.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfKeywordAndMatchType }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfKeywordAndMatchType")
-    public JAXBElement<ArrayOfKeywordAndMatchType> createArrayOfKeywordAndMatchType(ArrayOfKeywordAndMatchType value) {
-        return new JAXBElement<ArrayOfKeywordAndMatchType>(_ArrayOfKeywordAndMatchType_QNAME, ArrayOfKeywordAndMatchType.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link KeywordDemographic }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "KeywordDemographic")
-    public JAXBElement<KeywordDemographic> createKeywordDemographic(KeywordDemographic value) {
-        return new JAXBElement<KeywordDemographic>(_KeywordDemographic_QNAME, KeywordDemographic.class, null, value);
-    }
-
-    /**
      * Create an instance of {@link JAXBElement }{@code <}{@link Criterion }{@code >}}
      * 
      */
     @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "Criterion")
     public JAXBElement<Criterion> createCriterion(Criterion value) {
         return new JAXBElement<Criterion>(_Criterion_QNAME, Criterion.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfHistoricalSearchCountPeriodic }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfHistoricalSearchCountPeriodic")
-    public JAXBElement<ArrayOfHistoricalSearchCountPeriodic> createArrayOfHistoricalSearchCountPeriodic(ArrayOfHistoricalSearchCountPeriodic value) {
-        return new JAXBElement<ArrayOfHistoricalSearchCountPeriodic>(_ArrayOfHistoricalSearchCountPeriodic_QNAME, ArrayOfHistoricalSearchCountPeriodic.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link TrafficEstimate }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "TrafficEstimate")
-    public JAXBElement<TrafficEstimate> createTrafficEstimate(TrafficEstimate value) {
-        return new JAXBElement<TrafficEstimate>(_TrafficEstimate_QNAME, TrafficEstimate.class, null, value);
     }
 
     /**
@@ -1976,33 +2021,6 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link KeywordIdEstimatedPosition }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "KeywordIdEstimatedPosition")
-    public JAXBElement<KeywordIdEstimatedPosition> createKeywordIdEstimatedPosition(KeywordIdEstimatedPosition value) {
-        return new JAXBElement<KeywordIdEstimatedPosition>(_KeywordIdEstimatedPosition_QNAME, KeywordIdEstimatedPosition.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link NetworkType }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "NetworkType")
-    public JAXBElement<NetworkType> createNetworkType(NetworkType value) {
-        return new JAXBElement<NetworkType>(_NetworkType_QNAME, NetworkType.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link NetworkSearchParameter }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "NetworkSearchParameter")
-    public JAXBElement<NetworkSearchParameter> createNetworkSearchParameter(NetworkSearchParameter value) {
-        return new JAXBElement<NetworkSearchParameter>(_NetworkSearchParameter_QNAME, NetworkSearchParameter.class, null, value);
-    }
-
-    /**
      * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfCompetitionLevel }{@code >}}
      * 
      */
@@ -2021,15 +2039,6 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link SearchCountsByAttributes }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "SearchCountsByAttributes")
-    public JAXBElement<SearchCountsByAttributes> createSearchCountsByAttributes(SearchCountsByAttributes value) {
-        return new JAXBElement<SearchCountsByAttributes>(_SearchCountsByAttributes_QNAME, SearchCountsByAttributes.class, null, value);
-    }
-
-    /**
      * Create an instance of {@link JAXBElement }{@code <}{@link Short }{@code >}}
      * 
      */
@@ -2039,12 +2048,12 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link KeywordSearchCount }{@code >}}
+     * Create an instance of {@link JAXBElement }{@code <}{@link AutoApplyRecommendationsInfo }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "KeywordSearchCount")
-    public JAXBElement<KeywordSearchCount> createKeywordSearchCount(KeywordSearchCount value) {
-        return new JAXBElement<KeywordSearchCount>(_KeywordSearchCount_QNAME, KeywordSearchCount.class, null, value);
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "AutoApplyRecommendationsInfo")
+    public JAXBElement<AutoApplyRecommendationsInfo> createAutoApplyRecommendationsInfo(AutoApplyRecommendationsInfo value) {
+        return new JAXBElement<AutoApplyRecommendationsInfo>(_AutoApplyRecommendationsInfo_QNAME, AutoApplyRecommendationsInfo.class, null, value);
     }
 
     /**
@@ -2057,57 +2066,12 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfKeywordOpportunity }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfKeywordOpportunity")
-    public JAXBElement<ArrayOfKeywordOpportunity> createArrayOfKeywordOpportunity(ArrayOfKeywordOpportunity value) {
-        return new JAXBElement<ArrayOfKeywordOpportunity>(_ArrayOfKeywordOpportunity_QNAME, ArrayOfKeywordOpportunity.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfKeywordEstimatedBid }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfKeywordEstimatedBid")
-    public JAXBElement<ArrayOfKeywordEstimatedBid> createArrayOfKeywordEstimatedBid(ArrayOfKeywordEstimatedBid value) {
-        return new JAXBElement<ArrayOfKeywordEstimatedBid>(_ArrayOfKeywordEstimatedBid_QNAME, ArrayOfKeywordEstimatedBid.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link Boolean }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://schemas.microsoft.com/2003/10/Serialization/", name = "boolean")
-    public JAXBElement<Boolean> createBoolean(Boolean value) {
-        return new JAXBElement<Boolean>(_Boolean_QNAME, Boolean.class, null, value);
-    }
-
-    /**
      * Create an instance of {@link JAXBElement }{@code <}{@link String }{@code >}}
      * 
      */
     @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "UserName")
     public JAXBElement<String> createUserName(String value) {
         return new JAXBElement<String>(_UserName_QNAME, String.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link KeywordEstimatedBid }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "KeywordEstimatedBid")
-    public JAXBElement<KeywordEstimatedBid> createKeywordEstimatedBid(KeywordEstimatedBid value) {
-        return new JAXBElement<KeywordEstimatedBid>(_KeywordEstimatedBid_QNAME, KeywordEstimatedBid.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfBatchError }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfBatchError")
-    public JAXBElement<ArrayOfBatchError> createArrayOfBatchError(ArrayOfBatchError value) {
-        return new JAXBElement<ArrayOfBatchError>(_ArrayOfBatchError_QNAME, ArrayOfBatchError.class, null, value);
     }
 
     /**
@@ -2129,24 +2093,6 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link NegativeKeyword }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "NegativeKeyword")
-    public JAXBElement<NegativeKeyword> createNegativeKeyword(NegativeKeyword value) {
-        return new JAXBElement<NegativeKeyword>(_NegativeKeyword_QNAME, NegativeKeyword.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfKeywordEstimatedPosition }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfKeywordEstimatedPosition")
-    public JAXBElement<ArrayOfKeywordEstimatedPosition> createArrayOfKeywordEstimatedPosition(ArrayOfKeywordEstimatedPosition value) {
-        return new JAXBElement<ArrayOfKeywordEstimatedPosition>(_ArrayOfKeywordEstimatedPosition_QNAME, ArrayOfKeywordEstimatedPosition.class, null, value);
-    }
-
-    /**
      * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfCampaignEstimator }{@code >}}
      * 
      */
@@ -2165,21 +2111,12 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ApiFaultDetail }{@code >}}
+     * Create an instance of {@link JAXBElement }{@code <}{@link KPIType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ApiFaultDetail")
-    public JAXBElement<ApiFaultDetail> createApiFaultDetail(ApiFaultDetail value) {
-        return new JAXBElement<ApiFaultDetail>(_ApiFaultDetail_QNAME, ApiFaultDetail.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link Integer }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://schemas.microsoft.com/2003/10/Serialization/", name = "int")
-    public JAXBElement<Integer> createInt(Integer value) {
-        return new JAXBElement<Integer>(_Int_QNAME, Integer.class, null, value);
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "KPIType")
+    public JAXBElement<KPIType> createKPIType(KPIType value) {
+        return new JAXBElement<KPIType>(_KPIType_QNAME, KPIType.class, null, value);
     }
 
     /**
@@ -2192,48 +2129,12 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link MetricData }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "MetricData")
-    public JAXBElement<MetricData> createMetricData(MetricData value) {
-        return new JAXBElement<MetricData>(_MetricData_QNAME, MetricData.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfKeywordIdEstimatedPosition }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfKeywordIdEstimatedPosition")
-    public JAXBElement<ArrayOfKeywordIdEstimatedPosition> createArrayOfKeywordIdEstimatedPosition(ArrayOfKeywordIdEstimatedPosition value) {
-        return new JAXBElement<ArrayOfKeywordIdEstimatedPosition>(_ArrayOfKeywordIdEstimatedPosition_QNAME, ArrayOfKeywordIdEstimatedPosition.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfLanguageCriterion }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfLanguageCriterion")
-    public JAXBElement<ArrayOfLanguageCriterion> createArrayOfLanguageCriterion(ArrayOfLanguageCriterion value) {
-        return new JAXBElement<ArrayOfLanguageCriterion>(_ArrayOfLanguageCriterion_QNAME, ArrayOfLanguageCriterion.class, null, value);
-    }
-
-    /**
      * Create an instance of {@link JAXBElement }{@code <}{@link QName }{@code >}}
      * 
      */
     @XmlElementDecl(namespace = "http://schemas.microsoft.com/2003/10/Serialization/", name = "QName")
     public JAXBElement<QName> createQName(QName value) {
         return new JAXBElement<QName>(_QName_QNAME, QName.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfKeywordIdeaCategory }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfKeywordIdeaCategory")
-    public JAXBElement<ArrayOfKeywordIdeaCategory> createArrayOfKeywordIdeaCategory(ArrayOfKeywordIdeaCategory value) {
-        return new JAXBElement<ArrayOfKeywordIdeaCategory>(_ArrayOfKeywordIdeaCategory_QNAME, ArrayOfKeywordIdeaCategory.class, null, value);
     }
 
     /**
@@ -2246,30 +2147,21 @@ public class ObjectFactory {
     }
 
     /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link PerformanceInsightsMessageParameter }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "PerformanceInsightsMessageParameter")
+    public JAXBElement<PerformanceInsightsMessageParameter> createPerformanceInsightsMessageParameter(PerformanceInsightsMessageParameter value) {
+        return new JAXBElement<PerformanceInsightsMessageParameter>(_PerformanceInsightsMessageParameter_QNAME, PerformanceInsightsMessageParameter.class, null, value);
+    }
+
+    /**
      * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfAdGroupEstimator }{@code >}}
      * 
      */
     @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfAdGroupEstimator")
     public JAXBElement<ArrayOfAdGroupEstimator> createArrayOfAdGroupEstimator(ArrayOfAdGroupEstimator value) {
         return new JAXBElement<ArrayOfAdGroupEstimator>(_ArrayOfAdGroupEstimator_QNAME, ArrayOfAdGroupEstimator.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfBroadMatchSearchQueryKPI }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfBroadMatchSearchQueryKPI")
-    public JAXBElement<ArrayOfBroadMatchSearchQueryKPI> createArrayOfBroadMatchSearchQueryKPI(ArrayOfBroadMatchSearchQueryKPI value) {
-        return new JAXBElement<ArrayOfBroadMatchSearchQueryKPI>(_ArrayOfBroadMatchSearchQueryKPI_QNAME, ArrayOfBroadMatchSearchQueryKPI.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link Short }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://schemas.microsoft.com/2003/10/Serialization/", name = "unsignedByte")
-    public JAXBElement<Short> createUnsignedByte(Short value) {
-        return new JAXBElement<Short>(_UnsignedByte_QNAME, Short.class, null, value);
     }
 
     /**
@@ -2282,30 +2174,12 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfMatchType }{@code >}}
+     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfEntityDetail }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfMatchType")
-    public JAXBElement<ArrayOfMatchType> createArrayOfMatchType(ArrayOfMatchType value) {
-        return new JAXBElement<ArrayOfMatchType>(_ArrayOfMatchType_QNAME, ArrayOfMatchType.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfKeywordKPI }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfKeywordKPI")
-    public JAXBElement<ArrayOfKeywordKPI> createArrayOfKeywordKPI(ArrayOfKeywordKPI value) {
-        return new JAXBElement<ArrayOfKeywordKPI>(_ArrayOfKeywordKPI_QNAME, ArrayOfKeywordKPI.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfAuctionInsightKpi }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfAuctionInsightKpi")
-    public JAXBElement<ArrayOfAuctionInsightKpi> createArrayOfAuctionInsightKpi(ArrayOfAuctionInsightKpi value) {
-        return new JAXBElement<ArrayOfAuctionInsightKpi>(_ArrayOfAuctionInsightKpi_QNAME, ArrayOfAuctionInsightKpi.class, null, value);
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfEntityDetail")
+    public JAXBElement<ArrayOfEntityDetail> createArrayOfEntityDetail(ArrayOfEntityDetail value) {
+        return new JAXBElement<ArrayOfEntityDetail>(_ArrayOfEntityDetail_QNAME, ArrayOfEntityDetail.class, null, value);
     }
 
     /**
@@ -2345,75 +2219,12 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link KeywordIdEstimatedBid }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "KeywordIdEstimatedBid")
-    public JAXBElement<KeywordIdEstimatedBid> createKeywordIdEstimatedBid(KeywordIdEstimatedBid value) {
-        return new JAXBElement<KeywordIdEstimatedBid>(_KeywordIdEstimatedBid_QNAME, KeywordIdEstimatedBid.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link String }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ApplicationToken")
-    public JAXBElement<String> createApplicationToken(String value) {
-        return new JAXBElement<String>(_ApplicationToken_QNAME, String.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link Float }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://schemas.microsoft.com/2003/10/Serialization/", name = "float")
-    public JAXBElement<Float> createFloat(Float value) {
-        return new JAXBElement<Float>(_Float_QNAME, Float.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link KeywordIdea }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "KeywordIdea")
-    public JAXBElement<KeywordIdea> createKeywordIdea(KeywordIdea value) {
-        return new JAXBElement<KeywordIdea>(_KeywordIdea_QNAME, KeywordIdea.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfMetricData }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfMetricData")
-    public JAXBElement<ArrayOfMetricData> createArrayOfMetricData(ArrayOfMetricData value) {
-        return new JAXBElement<ArrayOfMetricData>(_ArrayOfMetricData_QNAME, ArrayOfMetricData.class, null, value);
-    }
-
-    /**
      * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfKeywordLocation }{@code >}}
      * 
      */
     @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfKeywordLocation")
     public JAXBElement<ArrayOfKeywordLocation> createArrayOfKeywordLocation(ArrayOfKeywordLocation value) {
         return new JAXBElement<ArrayOfKeywordLocation>(_ArrayOfKeywordLocation_QNAME, ArrayOfKeywordLocation.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link KeywordLocation }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "KeywordLocation")
-    public JAXBElement<KeywordLocation> createKeywordLocation(KeywordLocation value) {
-        return new JAXBElement<KeywordLocation>(_KeywordLocation_QNAME, KeywordLocation.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AdApiError }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://adapi.microsoft.com", name = "AdApiError")
-    public JAXBElement<AdApiError> createAdApiError(AdApiError value) {
-        return new JAXBElement<AdApiError>(_AdApiError_QNAME, AdApiError.class, null, value);
     }
 
     /**
@@ -2432,15 +2243,6 @@ public class ObjectFactory {
     @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfCampaignEstimate")
     public JAXBElement<ArrayOfCampaignEstimate> createArrayOfCampaignEstimate(ArrayOfCampaignEstimate value) {
         return new JAXBElement<ArrayOfCampaignEstimate>(_ArrayOfCampaignEstimate_QNAME, ArrayOfCampaignEstimate.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link LocationCriterion }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "LocationCriterion")
-    public JAXBElement<LocationCriterion> createLocationCriterion(LocationCriterion value) {
-        return new JAXBElement<LocationCriterion>(_LocationCriterion_QNAME, LocationCriterion.class, null, value);
     }
 
     /**
@@ -2477,15 +2279,6 @@ public class ObjectFactory {
     @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "KeywordLocationResult")
     public JAXBElement<KeywordLocationResult> createKeywordLocationResult(KeywordLocationResult value) {
         return new JAXBElement<KeywordLocationResult>(_KeywordLocationResult_QNAME, KeywordLocationResult.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link LanguageSearchParameter }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "LanguageSearchParameter")
-    public JAXBElement<LanguageSearchParameter> createLanguageSearchParameter(LanguageSearchParameter value) {
-        return new JAXBElement<LanguageSearchParameter>(_LanguageSearchParameter_QNAME, LanguageSearchParameter.class, null, value);
     }
 
     /**
@@ -2534,52 +2327,6 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link Collection }{@code <}{@link BidOpportunityType }{@code >}{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "BidOpportunityType")
-    @XmlJavaTypeAdapter(Adapter3 .class)
-    public JAXBElement<Collection<BidOpportunityType>> createBidOpportunityType(Collection<BidOpportunityType> value) {
-        return new JAXBElement<Collection<BidOpportunityType>>(_BidOpportunityType_QNAME, ((Class) Collection.class), null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link byte[]}{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://schemas.microsoft.com/2003/10/Serialization/", name = "base64Binary")
-    public JAXBElement<byte[]> createBase64Binary(byte[] value) {
-        return new JAXBElement<byte[]>(_Base64Binary_QNAME, byte[].class, null, ((byte[]) value));
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link CampaignEstimator }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "CampaignEstimator")
-    public JAXBElement<CampaignEstimator> createCampaignEstimator(CampaignEstimator value) {
-        return new JAXBElement<CampaignEstimator>(_CampaignEstimator_QNAME, CampaignEstimator.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfEstimatedPositionAndTraffic }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfEstimatedPositionAndTraffic")
-    public JAXBElement<ArrayOfEstimatedPositionAndTraffic> createArrayOfEstimatedPositionAndTraffic(ArrayOfEstimatedPositionAndTraffic value) {
-        return new JAXBElement<ArrayOfEstimatedPositionAndTraffic>(_ArrayOfEstimatedPositionAndTraffic_QNAME, ArrayOfEstimatedPositionAndTraffic.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link EntityType }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "EntityType")
-    public JAXBElement<EntityType> createEntityType(EntityType value) {
-        return new JAXBElement<EntityType>(_EntityType_QNAME, EntityType.class, null, value);
-    }
-
-    /**
      * Create an instance of {@link JAXBElement }{@code <}{@link LanguageCriterion }{@code >}}
      * 
      */
@@ -2595,24 +2342,6 @@ public class ObjectFactory {
     @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "KeywordOpportunity")
     public JAXBElement<KeywordOpportunity> createKeywordOpportunity(KeywordOpportunity value) {
         return new JAXBElement<KeywordOpportunity>(_KeywordOpportunity_QNAME, KeywordOpportunity.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfAdGroupBidLandscapeInput }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfAdGroupBidLandscapeInput")
-    public JAXBElement<ArrayOfAdGroupBidLandscapeInput> createArrayOfAdGroupBidLandscapeInput(ArrayOfAdGroupBidLandscapeInput value) {
-        return new JAXBElement<ArrayOfAdGroupBidLandscapeInput>(_ArrayOfAdGroupBidLandscapeInput_QNAME, ArrayOfAdGroupBidLandscapeInput.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ExcludeAccountKeywordsSearchParameter }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ExcludeAccountKeywordsSearchParameter")
-    public JAXBElement<ExcludeAccountKeywordsSearchParameter> createExcludeAccountKeywordsSearchParameter(ExcludeAccountKeywordsSearchParameter value) {
-        return new JAXBElement<ExcludeAccountKeywordsSearchParameter>(_ExcludeAccountKeywordsSearchParameter_QNAME, ExcludeAccountKeywordsSearchParameter.class, null, value);
     }
 
     /**
@@ -2634,15 +2363,6 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AdPosition }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "AdPosition")
-    public JAXBElement<AdPosition> createAdPosition(AdPosition value) {
-        return new JAXBElement<AdPosition>(_AdPosition_QNAME, AdPosition.class, null, value);
-    }
-
-    /**
      * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOflong }{@code >}}
      * 
      */
@@ -2658,6 +2378,24 @@ public class ObjectFactory {
     @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfKeywordIdeaAttribute")
     public JAXBElement<ArrayOfKeywordIdeaAttribute> createArrayOfKeywordIdeaAttribute(ArrayOfKeywordIdeaAttribute value) {
         return new JAXBElement<ArrayOfKeywordIdeaAttribute>(_ArrayOfKeywordIdeaAttribute_QNAME, ArrayOfKeywordIdeaAttribute.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfPerformanceInsightsMessageParameter }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfPerformanceInsightsMessageParameter")
+    public JAXBElement<ArrayOfPerformanceInsightsMessageParameter> createArrayOfPerformanceInsightsMessageParameter(ArrayOfPerformanceInsightsMessageParameter value) {
+        return new JAXBElement<ArrayOfPerformanceInsightsMessageParameter>(_ArrayOfPerformanceInsightsMessageParameter_QNAME, ArrayOfPerformanceInsightsMessageParameter.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link PerformanceInsightsUrlCategory }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "PerformanceInsightsUrlCategory")
+    public JAXBElement<PerformanceInsightsUrlCategory> createPerformanceInsightsUrlCategory(PerformanceInsightsUrlCategory value) {
+        return new JAXBElement<PerformanceInsightsUrlCategory>(_PerformanceInsightsUrlCategory_QNAME, PerformanceInsightsUrlCategory.class, null, value);
     }
 
     /**
@@ -2679,15 +2417,6 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfSearchCountsByAttributes }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfSearchCountsByAttributes")
-    public JAXBElement<ArrayOfSearchCountsByAttributes> createArrayOfSearchCountsByAttributes(ArrayOfSearchCountsByAttributes value) {
-        return new JAXBElement<ArrayOfSearchCountsByAttributes>(_ArrayOfSearchCountsByAttributes_QNAME, ArrayOfSearchCountsByAttributes.class, null, value);
-    }
-
-    /**
      * Create an instance of {@link JAXBElement }{@code <}{@link Long }{@code >}}
      * 
      */
@@ -2697,50 +2426,12 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link SearchParameter }{@code >}}
+     * Create an instance of {@link JAXBElement }{@code <}{@link TextParameter }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "SearchParameter")
-    public JAXBElement<SearchParameter> createSearchParameter(SearchParameter value) {
-        return new JAXBElement<SearchParameter>(_SearchParameter_QNAME, SearchParameter.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link SearchVolumeSearchParameter }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "SearchVolumeSearchParameter")
-    public JAXBElement<SearchVolumeSearchParameter> createSearchVolumeSearchParameter(SearchVolumeSearchParameter value) {
-        return new JAXBElement<SearchVolumeSearchParameter>(_SearchVolumeSearchParameter_QNAME, SearchVolumeSearchParameter.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link Collection }{@code <}{@link AuctionInsightKpiAdditionalField }{@code >}{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "AuctionInsightKpiAdditionalField")
-    @XmlJavaTypeAdapter(Adapter2 .class)
-    public JAXBElement<Collection<AuctionInsightKpiAdditionalField>> createAuctionInsightKpiAdditionalField(Collection<AuctionInsightKpiAdditionalField> value) {
-        return new JAXBElement<Collection<AuctionInsightKpiAdditionalField>>(_AuctionInsightKpiAdditionalField_QNAME, ((Class) Collection.class), null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link KeywordEstimatedPosition }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "KeywordEstimatedPosition")
-    public JAXBElement<KeywordEstimatedPosition> createKeywordEstimatedPosition(KeywordEstimatedPosition value) {
-        return new JAXBElement<KeywordEstimatedPosition>(_KeywordEstimatedPosition_QNAME, KeywordEstimatedPosition.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link Calendar }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://schemas.microsoft.com/2003/10/Serialization/", name = "dateTime")
-    @XmlJavaTypeAdapter(Adapter1 .class)
-    public JAXBElement<Calendar> createDateTime(Calendar value) {
-        return new JAXBElement<Calendar>(_DateTime_QNAME, Calendar.class, null, value);
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "TextParameter")
+    public JAXBElement<TextParameter> createTextParameter(TextParameter value) {
+        return new JAXBElement<TextParameter>(_TextParameter_QNAME, TextParameter.class, null, value);
     }
 
     /**
@@ -2750,51 +2441,6 @@ public class ObjectFactory {
     @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "CampaignEstimate")
     public JAXBElement<CampaignEstimate> createCampaignEstimate(CampaignEstimate value) {
         return new JAXBElement<CampaignEstimate>(_CampaignEstimate_QNAME, CampaignEstimate.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfLocationCriterion }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfLocationCriterion")
-    public JAXBElement<ArrayOfLocationCriterion> createArrayOfLocationCriterion(ArrayOfLocationCriterion value) {
-        return new JAXBElement<ArrayOfLocationCriterion>(_ArrayOfLocationCriterion_QNAME, ArrayOfLocationCriterion.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link KeywordEstimator }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "KeywordEstimator")
-    public JAXBElement<KeywordEstimator> createKeywordEstimator(KeywordEstimator value) {
-        return new JAXBElement<KeywordEstimator>(_KeywordEstimator_QNAME, KeywordEstimator.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AdGroupEstimator }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "AdGroupEstimator")
-    public JAXBElement<AdGroupEstimator> createAdGroupEstimator(AdGroupEstimator value) {
-        return new JAXBElement<AdGroupEstimator>(_AdGroupEstimator_QNAME, AdGroupEstimator.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link Char }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://schemas.microsoft.com/2003/10/Serialization/", name = "char")
-    public JAXBElement<Char> createChar(Char value) {
-        return new JAXBElement<Char>(_Char_QNAME, Char.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link DomainCategory }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "DomainCategory")
-    public JAXBElement<DomainCategory> createDomainCategory(DomainCategory value) {
-        return new JAXBElement<DomainCategory>(_DomainCategory_QNAME, DomainCategory.class, null, value);
     }
 
     /**
@@ -2816,30 +2462,12 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link SuggestedBidSearchParameter }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "SuggestedBidSearchParameter")
-    public JAXBElement<SuggestedBidSearchParameter> createSuggestedBidSearchParameter(SuggestedBidSearchParameter value) {
-        return new JAXBElement<SuggestedBidSearchParameter>(_SuggestedBidSearchParameter_QNAME, SuggestedBidSearchParameter.class, null, value);
-    }
-
-    /**
      * Create an instance of {@link JAXBElement }{@code <}{@link AuctionSegment }{@code >}}
      * 
      */
     @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "AuctionSegment")
     public JAXBElement<AuctionSegment> createAuctionSegment(AuctionSegment value) {
         return new JAXBElement<AuctionSegment>(_AuctionSegment_QNAME, AuctionSegment.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link Keyword }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "Keyword")
-    public JAXBElement<Keyword> createKeyword(Keyword value) {
-        return new JAXBElement<Keyword>(_Keyword_QNAME, Keyword.class, null, value);
     }
 
     /**
@@ -2852,30 +2480,12 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link LocationSearchParameter }{@code >}}
+     * Create an instance of {@link JAXBElement }{@code <}{@link PerformanceInsightsEntityType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "LocationSearchParameter")
-    public JAXBElement<LocationSearchParameter> createLocationSearchParameter(LocationSearchParameter value) {
-        return new JAXBElement<LocationSearchParameter>(_LocationSearchParameter_QNAME, LocationSearchParameter.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link KeywordDemographicResult }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "KeywordDemographicResult")
-    public JAXBElement<KeywordDemographicResult> createKeywordDemographicResult(KeywordDemographicResult value) {
-        return new JAXBElement<KeywordDemographicResult>(_KeywordDemographicResult_QNAME, KeywordDemographicResult.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfKeywordSuggestion }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfKeywordSuggestion")
-    public JAXBElement<ArrayOfKeywordSuggestion> createArrayOfKeywordSuggestion(ArrayOfKeywordSuggestion value) {
-        return new JAXBElement<ArrayOfKeywordSuggestion>(_ArrayOfKeywordSuggestion_QNAME, ArrayOfKeywordSuggestion.class, null, value);
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "PerformanceInsightsEntityType")
+    public JAXBElement<PerformanceInsightsEntityType> createPerformanceInsightsEntityType(PerformanceInsightsEntityType value) {
+        return new JAXBElement<PerformanceInsightsEntityType>(_PerformanceInsightsEntityType_QNAME, PerformanceInsightsEntityType.class, null, value);
     }
 
     /**
@@ -2942,42 +2552,6 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link DayMonthAndYear }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "DayMonthAndYear")
-    public JAXBElement<DayMonthAndYear> createDayMonthAndYear(DayMonthAndYear value) {
-        return new JAXBElement<DayMonthAndYear>(_DayMonthAndYear_QNAME, DayMonthAndYear.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link UnsignedLong }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://schemas.microsoft.com/2003/10/Serialization/", name = "unsignedLong")
-    public JAXBElement<UnsignedLong> createUnsignedLong(UnsignedLong value) {
-        return new JAXBElement<UnsignedLong>(_UnsignedLong_QNAME, UnsignedLong.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfEstimatedBidAndTraffic }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfEstimatedBidAndTraffic")
-    public JAXBElement<ArrayOfEstimatedBidAndTraffic> createArrayOfEstimatedBidAndTraffic(ArrayOfEstimatedBidAndTraffic value) {
-        return new JAXBElement<ArrayOfEstimatedBidAndTraffic>(_ArrayOfEstimatedBidAndTraffic_QNAME, ArrayOfEstimatedBidAndTraffic.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link Integer }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://schemas.microsoft.com/2003/10/Serialization/", name = "unsignedShort")
-    public JAXBElement<Integer> createUnsignedShort(Integer value) {
-        return new JAXBElement<Integer>(_UnsignedShort_QNAME, Integer.class, null, value);
-    }
-
-    /**
      * Create an instance of {@link JAXBElement }{@code <}{@link KeywordBidLandscape }{@code >}}
      * 
      */
@@ -3032,24 +2606,6 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link BidOpportunity }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "BidOpportunity")
-    public JAXBElement<BidOpportunity> createBidOpportunity(BidOpportunity value) {
-        return new JAXBElement<BidOpportunity>(_BidOpportunity_QNAME, BidOpportunity.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfKeywordIdEstimatedBid }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfKeywordIdEstimatedBid")
-    public JAXBElement<ArrayOfKeywordIdEstimatedBid> createArrayOfKeywordIdEstimatedBid(ArrayOfKeywordIdEstimatedBid value) {
-        return new JAXBElement<ArrayOfKeywordIdEstimatedBid>(_ArrayOfKeywordIdEstimatedBid_QNAME, ArrayOfKeywordIdEstimatedBid.class, null, value);
-    }
-
-    /**
      * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfKeywordCategory }{@code >}}
      * 
      */
@@ -3095,39 +2651,12 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfBudgetOpportunity }{@code >}}
+     * Create an instance of {@link JAXBElement }{@code <}{@link EntityParameter }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfBudgetOpportunity")
-    public JAXBElement<ArrayOfBudgetOpportunity> createArrayOfBudgetOpportunity(ArrayOfBudgetOpportunity value) {
-        return new JAXBElement<ArrayOfBudgetOpportunity>(_ArrayOfBudgetOpportunity_QNAME, ArrayOfBudgetOpportunity.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link BroadMatchSearchQueryKPI }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "BroadMatchSearchQueryKPI")
-    public JAXBElement<BroadMatchSearchQueryKPI> createBroadMatchSearchQueryKPI(BroadMatchSearchQueryKPI value) {
-        return new JAXBElement<BroadMatchSearchQueryKPI>(_BroadMatchSearchQueryKPI_QNAME, BroadMatchSearchQueryKPI.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link BudgetPoint }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "BudgetPoint")
-    public JAXBElement<BudgetPoint> createBudgetPoint(BudgetPoint value) {
-        return new JAXBElement<BudgetPoint>(_BudgetPoint_QNAME, BudgetPoint.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link KeywordIdeaCategory }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "KeywordIdeaCategory")
-    public JAXBElement<KeywordIdeaCategory> createKeywordIdeaCategory(KeywordIdeaCategory value) {
-        return new JAXBElement<KeywordIdeaCategory>(_KeywordIdeaCategory_QNAME, KeywordIdeaCategory.class, null, value);
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "EntityParameter")
+    public JAXBElement<EntityParameter> createEntityParameter(EntityParameter value) {
+        return new JAXBElement<EntityParameter>(_EntityParameter_QNAME, EntityParameter.class, null, value);
     }
 
     /**
@@ -3140,30 +2669,12 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link String }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "CustomerId")
-    public JAXBElement<String> createCustomerId(String value) {
-        return new JAXBElement<String>(_CustomerId_QNAME, String.class, null, value);
-    }
-
-    /**
      * Create an instance of {@link JAXBElement }{@code <}{@link KeywordAndConfidence }{@code >}}
      * 
      */
     @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "KeywordAndConfidence")
     public JAXBElement<KeywordAndConfidence> createKeywordAndConfidence(KeywordAndConfidence value) {
         return new JAXBElement<KeywordAndConfidence>(_KeywordAndConfidence_QNAME, KeywordAndConfidence.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AdApiFaultDetail }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://adapi.microsoft.com", name = "AdApiFaultDetail")
-    public JAXBElement<AdApiFaultDetail> createAdApiFaultDetail(AdApiFaultDetail value) {
-        return new JAXBElement<AdApiFaultDetail>(_AdApiFaultDetail_QNAME, AdApiFaultDetail.class, null, value);
     }
 
     /**
@@ -3176,40 +2687,12 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link Collection }{@code <}{@link KeywordOpportunityType }{@code >}{@code >}}
+     * Create an instance of {@link JAXBElement }{@code <}{@link PerformanceInsightsMessageTemplateId }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "KeywordOpportunityType")
-    @XmlJavaTypeAdapter(Adapter4 .class)
-    public JAXBElement<Collection<KeywordOpportunityType>> createKeywordOpportunityType(Collection<KeywordOpportunityType> value) {
-        return new JAXBElement<Collection<KeywordOpportunityType>>(_KeywordOpportunityType_QNAME, ((Class) Collection.class), null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link KeywordHistoricalPerformance }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "KeywordHistoricalPerformance")
-    public JAXBElement<KeywordHistoricalPerformance> createKeywordHistoricalPerformance(KeywordHistoricalPerformance value) {
-        return new JAXBElement<KeywordHistoricalPerformance>(_KeywordHistoricalPerformance_QNAME, KeywordHistoricalPerformance.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ApplicationFault }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://adapi.microsoft.com", name = "ApplicationFault")
-    public JAXBElement<ApplicationFault> createApplicationFault(ApplicationFault value) {
-        return new JAXBElement<ApplicationFault>(_ApplicationFault_QNAME, ApplicationFault.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link BidLandscapePoint }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "BidLandscapePoint")
-    public JAXBElement<BidLandscapePoint> createBidLandscapePoint(BidLandscapePoint value) {
-        return new JAXBElement<BidLandscapePoint>(_BidLandscapePoint_QNAME, BidLandscapePoint.class, null, value);
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "PerformanceInsightsMessageTemplateId")
+    public JAXBElement<PerformanceInsightsMessageTemplateId> createPerformanceInsightsMessageTemplateId(PerformanceInsightsMessageTemplateId value) {
+        return new JAXBElement<PerformanceInsightsMessageTemplateId>(_PerformanceInsightsMessageTemplateId_QNAME, PerformanceInsightsMessageTemplateId.class, null, value);
     }
 
     /**
@@ -3219,15 +2702,6 @@ public class ObjectFactory {
     @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "KeywordCategoryResult")
     public JAXBElement<KeywordCategoryResult> createKeywordCategoryResult(KeywordCategoryResult value) {
         return new JAXBElement<KeywordCategoryResult>(_KeywordCategoryResult_QNAME, KeywordCategoryResult.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link KeywordCategory }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "KeywordCategory")
-    public JAXBElement<KeywordCategory> createKeywordCategory(KeywordCategory value) {
-        return new JAXBElement<KeywordCategory>(_KeywordCategory_QNAME, KeywordCategory.class, null, value);
     }
 
     /**
@@ -3246,6 +2720,15 @@ public class ObjectFactory {
     @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "DeviceSearchParameter")
     public JAXBElement<DeviceSearchParameter> createDeviceSearchParameter(DeviceSearchParameter value) {
         return new JAXBElement<DeviceSearchParameter>(_DeviceSearchParameter_QNAME, DeviceSearchParameter.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link PerformanceInsightsDetail }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "PerformanceInsightsDetail")
+    public JAXBElement<PerformanceInsightsDetail> createPerformanceInsightsDetail(PerformanceInsightsDetail value) {
+        return new JAXBElement<PerformanceInsightsDetail>(_PerformanceInsightsDetail_QNAME, PerformanceInsightsDetail.class, null, value);
     }
 
     /**
@@ -3312,6 +2795,874 @@ public class ObjectFactory {
     }
 
     /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfAuctionSegment }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfAuctionSegment")
+    public JAXBElement<ArrayOfAuctionSegment> createArrayOfAuctionSegment(ArrayOfAuctionSegment value) {
+        return new JAXBElement<ArrayOfAuctionSegment>(_ArrayOfAuctionSegment_QNAME, ArrayOfAuctionSegment.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AdGroupBidLandscapeType }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "AdGroupBidLandscapeType")
+    public JAXBElement<AdGroupBidLandscapeType> createAdGroupBidLandscapeType(AdGroupBidLandscapeType value) {
+        return new JAXBElement<AdGroupBidLandscapeType>(_AdGroupBidLandscapeType_QNAME, AdGroupBidLandscapeType.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link KeywordKPI }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "KeywordKPI")
+    public JAXBElement<KeywordKPI> createKeywordKPI(KeywordKPI value) {
+        return new JAXBElement<KeywordKPI>(_KeywordKPI_QNAME, KeywordKPI.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfPerformanceInsightsDetail }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfPerformanceInsightsDetail")
+    public JAXBElement<ArrayOfPerformanceInsightsDetail> createArrayOfPerformanceInsightsDetail(ArrayOfPerformanceInsightsDetail value) {
+        return new JAXBElement<ArrayOfPerformanceInsightsDetail>(_ArrayOfPerformanceInsightsDetail_QNAME, ArrayOfPerformanceInsightsDetail.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link BudgetPointType }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "BudgetPointType")
+    public JAXBElement<BudgetPointType> createBudgetPointType(BudgetPointType value) {
+        return new JAXBElement<BudgetPointType>(_BudgetPointType_QNAME, BudgetPointType.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfBidLandscapePoint }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfBidLandscapePoint")
+    public JAXBElement<ArrayOfBidLandscapePoint> createArrayOfBidLandscapePoint(ArrayOfBidLandscapePoint value) {
+        return new JAXBElement<ArrayOfBidLandscapePoint>(_ArrayOfBidLandscapePoint_QNAME, ArrayOfBidLandscapePoint.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfOperationError }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfOperationError")
+    public JAXBElement<ArrayOfOperationError> createArrayOfOperationError(ArrayOfOperationError value) {
+        return new JAXBElement<ArrayOfOperationError>(_ArrayOfOperationError_QNAME, ArrayOfOperationError.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AdGroupEstimate }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "AdGroupEstimate")
+    public JAXBElement<AdGroupEstimate> createAdGroupEstimate(AdGroupEstimate value) {
+        return new JAXBElement<AdGroupEstimate>(_AdGroupEstimate_QNAME, AdGroupEstimate.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfCriterion }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfCriterion")
+    public JAXBElement<ArrayOfCriterion> createArrayOfCriterion(ArrayOfCriterion value) {
+        return new JAXBElement<ArrayOfCriterion>(_ArrayOfCriterion_QNAME, ArrayOfCriterion.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link PerformanceInsightsMessage }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "PerformanceInsightsMessage")
+    public JAXBElement<PerformanceInsightsMessage> createPerformanceInsightsMessage(PerformanceInsightsMessage value) {
+        return new JAXBElement<PerformanceInsightsMessage>(_PerformanceInsightsMessage_QNAME, PerformanceInsightsMessage.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfBidOpportunity }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfBidOpportunity")
+    public JAXBElement<ArrayOfBidOpportunity> createArrayOfBidOpportunity(ArrayOfBidOpportunity value) {
+        return new JAXBElement<ArrayOfBidOpportunity>(_ArrayOfBidOpportunity_QNAME, ArrayOfBidOpportunity.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link UrlParameter }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "UrlParameter")
+    public JAXBElement<UrlParameter> createUrlParameter(UrlParameter value) {
+        return new JAXBElement<UrlParameter>(_UrlParameter_QNAME, UrlParameter.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfAdApiError }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://adapi.microsoft.com", name = "ArrayOfAdApiError")
+    public JAXBElement<ArrayOfAdApiError> createArrayOfAdApiError(ArrayOfAdApiError value) {
+        return new JAXBElement<ArrayOfAdApiError>(_ArrayOfAdApiError_QNAME, ArrayOfAdApiError.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link BudgetOpportunity }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "BudgetOpportunity")
+    public JAXBElement<BudgetOpportunity> createBudgetOpportunity(BudgetOpportunity value) {
+        return new JAXBElement<BudgetOpportunity>(_BudgetOpportunity_QNAME, BudgetOpportunity.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfKeywordAndMatchType }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfKeywordAndMatchType")
+    public JAXBElement<ArrayOfKeywordAndMatchType> createArrayOfKeywordAndMatchType(ArrayOfKeywordAndMatchType value) {
+        return new JAXBElement<ArrayOfKeywordAndMatchType>(_ArrayOfKeywordAndMatchType_QNAME, ArrayOfKeywordAndMatchType.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link KeywordDemographic }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "KeywordDemographic")
+    public JAXBElement<KeywordDemographic> createKeywordDemographic(KeywordDemographic value) {
+        return new JAXBElement<KeywordDemographic>(_KeywordDemographic_QNAME, KeywordDemographic.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfHistoricalSearchCountPeriodic }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfHistoricalSearchCountPeriodic")
+    public JAXBElement<ArrayOfHistoricalSearchCountPeriodic> createArrayOfHistoricalSearchCountPeriodic(ArrayOfHistoricalSearchCountPeriodic value) {
+        return new JAXBElement<ArrayOfHistoricalSearchCountPeriodic>(_ArrayOfHistoricalSearchCountPeriodic_QNAME, ArrayOfHistoricalSearchCountPeriodic.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link TrafficEstimate }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "TrafficEstimate")
+    public JAXBElement<TrafficEstimate> createTrafficEstimate(TrafficEstimate value) {
+        return new JAXBElement<TrafficEstimate>(_TrafficEstimate_QNAME, TrafficEstimate.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link KeywordIdEstimatedPosition }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "KeywordIdEstimatedPosition")
+    public JAXBElement<KeywordIdEstimatedPosition> createKeywordIdEstimatedPosition(KeywordIdEstimatedPosition value) {
+        return new JAXBElement<KeywordIdEstimatedPosition>(_KeywordIdEstimatedPosition_QNAME, KeywordIdEstimatedPosition.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link NetworkType }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "NetworkType")
+    public JAXBElement<NetworkType> createNetworkType(NetworkType value) {
+        return new JAXBElement<NetworkType>(_NetworkType_QNAME, NetworkType.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link NetworkSearchParameter }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "NetworkSearchParameter")
+    public JAXBElement<NetworkSearchParameter> createNetworkSearchParameter(NetworkSearchParameter value) {
+        return new JAXBElement<NetworkSearchParameter>(_NetworkSearchParameter_QNAME, NetworkSearchParameter.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link SearchCountsByAttributes }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "SearchCountsByAttributes")
+    public JAXBElement<SearchCountsByAttributes> createSearchCountsByAttributes(SearchCountsByAttributes value) {
+        return new JAXBElement<SearchCountsByAttributes>(_SearchCountsByAttributes_QNAME, SearchCountsByAttributes.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link KeywordSearchCount }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "KeywordSearchCount")
+    public JAXBElement<KeywordSearchCount> createKeywordSearchCount(KeywordSearchCount value) {
+        return new JAXBElement<KeywordSearchCount>(_KeywordSearchCount_QNAME, KeywordSearchCount.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfKeywordOpportunity }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfKeywordOpportunity")
+    public JAXBElement<ArrayOfKeywordOpportunity> createArrayOfKeywordOpportunity(ArrayOfKeywordOpportunity value) {
+        return new JAXBElement<ArrayOfKeywordOpportunity>(_ArrayOfKeywordOpportunity_QNAME, ArrayOfKeywordOpportunity.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfKeywordEstimatedBid }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfKeywordEstimatedBid")
+    public JAXBElement<ArrayOfKeywordEstimatedBid> createArrayOfKeywordEstimatedBid(ArrayOfKeywordEstimatedBid value) {
+        return new JAXBElement<ArrayOfKeywordEstimatedBid>(_ArrayOfKeywordEstimatedBid_QNAME, ArrayOfKeywordEstimatedBid.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link Boolean }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://schemas.microsoft.com/2003/10/Serialization/", name = "boolean")
+    public JAXBElement<Boolean> createBoolean(Boolean value) {
+        return new JAXBElement<Boolean>(_Boolean_QNAME, Boolean.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link KeywordEstimatedBid }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "KeywordEstimatedBid")
+    public JAXBElement<KeywordEstimatedBid> createKeywordEstimatedBid(KeywordEstimatedBid value) {
+        return new JAXBElement<KeywordEstimatedBid>(_KeywordEstimatedBid_QNAME, KeywordEstimatedBid.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfBatchError }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfBatchError")
+    public JAXBElement<ArrayOfBatchError> createArrayOfBatchError(ArrayOfBatchError value) {
+        return new JAXBElement<ArrayOfBatchError>(_ArrayOfBatchError_QNAME, ArrayOfBatchError.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link NegativeKeyword }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "NegativeKeyword")
+    public JAXBElement<NegativeKeyword> createNegativeKeyword(NegativeKeyword value) {
+        return new JAXBElement<NegativeKeyword>(_NegativeKeyword_QNAME, NegativeKeyword.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfKeywordEstimatedPosition }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfKeywordEstimatedPosition")
+    public JAXBElement<ArrayOfKeywordEstimatedPosition> createArrayOfKeywordEstimatedPosition(ArrayOfKeywordEstimatedPosition value) {
+        return new JAXBElement<ArrayOfKeywordEstimatedPosition>(_ArrayOfKeywordEstimatedPosition_QNAME, ArrayOfKeywordEstimatedPosition.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ApiFaultDetail }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ApiFaultDetail")
+    public JAXBElement<ApiFaultDetail> createApiFaultDetail(ApiFaultDetail value) {
+        return new JAXBElement<ApiFaultDetail>(_ApiFaultDetail_QNAME, ApiFaultDetail.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link Integer }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://schemas.microsoft.com/2003/10/Serialization/", name = "int")
+    public JAXBElement<Integer> createInt(Integer value) {
+        return new JAXBElement<Integer>(_Int_QNAME, Integer.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link MetricData }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "MetricData")
+    public JAXBElement<MetricData> createMetricData(MetricData value) {
+        return new JAXBElement<MetricData>(_MetricData_QNAME, MetricData.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfPerformanceInsightsMessage }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfPerformanceInsightsMessage")
+    public JAXBElement<ArrayOfPerformanceInsightsMessage> createArrayOfPerformanceInsightsMessage(ArrayOfPerformanceInsightsMessage value) {
+        return new JAXBElement<ArrayOfPerformanceInsightsMessage>(_ArrayOfPerformanceInsightsMessage_QNAME, ArrayOfPerformanceInsightsMessage.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfKeywordIdEstimatedPosition }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfKeywordIdEstimatedPosition")
+    public JAXBElement<ArrayOfKeywordIdEstimatedPosition> createArrayOfKeywordIdEstimatedPosition(ArrayOfKeywordIdEstimatedPosition value) {
+        return new JAXBElement<ArrayOfKeywordIdEstimatedPosition>(_ArrayOfKeywordIdEstimatedPosition_QNAME, ArrayOfKeywordIdEstimatedPosition.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfLanguageCriterion }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfLanguageCriterion")
+    public JAXBElement<ArrayOfLanguageCriterion> createArrayOfLanguageCriterion(ArrayOfLanguageCriterion value) {
+        return new JAXBElement<ArrayOfLanguageCriterion>(_ArrayOfLanguageCriterion_QNAME, ArrayOfLanguageCriterion.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfKeywordIdeaCategory }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfKeywordIdeaCategory")
+    public JAXBElement<ArrayOfKeywordIdeaCategory> createArrayOfKeywordIdeaCategory(ArrayOfKeywordIdeaCategory value) {
+        return new JAXBElement<ArrayOfKeywordIdeaCategory>(_ArrayOfKeywordIdeaCategory_QNAME, ArrayOfKeywordIdeaCategory.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfBroadMatchSearchQueryKPI }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfBroadMatchSearchQueryKPI")
+    public JAXBElement<ArrayOfBroadMatchSearchQueryKPI> createArrayOfBroadMatchSearchQueryKPI(ArrayOfBroadMatchSearchQueryKPI value) {
+        return new JAXBElement<ArrayOfBroadMatchSearchQueryKPI>(_ArrayOfBroadMatchSearchQueryKPI_QNAME, ArrayOfBroadMatchSearchQueryKPI.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link Short }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://schemas.microsoft.com/2003/10/Serialization/", name = "unsignedByte")
+    public JAXBElement<Short> createUnsignedByte(Short value) {
+        return new JAXBElement<Short>(_UnsignedByte_QNAME, Short.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfMatchType }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfMatchType")
+    public JAXBElement<ArrayOfMatchType> createArrayOfMatchType(ArrayOfMatchType value) {
+        return new JAXBElement<ArrayOfMatchType>(_ArrayOfMatchType_QNAME, ArrayOfMatchType.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfKeywordKPI }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfKeywordKPI")
+    public JAXBElement<ArrayOfKeywordKPI> createArrayOfKeywordKPI(ArrayOfKeywordKPI value) {
+        return new JAXBElement<ArrayOfKeywordKPI>(_ArrayOfKeywordKPI_QNAME, ArrayOfKeywordKPI.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link PerformanceInsightsUrlId }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "PerformanceInsightsUrlId")
+    public JAXBElement<PerformanceInsightsUrlId> createPerformanceInsightsUrlId(PerformanceInsightsUrlId value) {
+        return new JAXBElement<PerformanceInsightsUrlId>(_PerformanceInsightsUrlId_QNAME, PerformanceInsightsUrlId.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfAuctionInsightKpi }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfAuctionInsightKpi")
+    public JAXBElement<ArrayOfAuctionInsightKpi> createArrayOfAuctionInsightKpi(ArrayOfAuctionInsightKpi value) {
+        return new JAXBElement<ArrayOfAuctionInsightKpi>(_ArrayOfAuctionInsightKpi_QNAME, ArrayOfAuctionInsightKpi.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link KeywordIdEstimatedBid }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "KeywordIdEstimatedBid")
+    public JAXBElement<KeywordIdEstimatedBid> createKeywordIdEstimatedBid(KeywordIdEstimatedBid value) {
+        return new JAXBElement<KeywordIdEstimatedBid>(_KeywordIdEstimatedBid_QNAME, KeywordIdEstimatedBid.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link String }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ApplicationToken")
+    public JAXBElement<String> createApplicationToken(String value) {
+        return new JAXBElement<String>(_ApplicationToken_QNAME, String.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link Float }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://schemas.microsoft.com/2003/10/Serialization/", name = "float")
+    public JAXBElement<Float> createFloat(Float value) {
+        return new JAXBElement<Float>(_Float_QNAME, Float.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link KeywordIdea }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "KeywordIdea")
+    public JAXBElement<KeywordIdea> createKeywordIdea(KeywordIdea value) {
+        return new JAXBElement<KeywordIdea>(_KeywordIdea_QNAME, KeywordIdea.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfMetricData }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfMetricData")
+    public JAXBElement<ArrayOfMetricData> createArrayOfMetricData(ArrayOfMetricData value) {
+        return new JAXBElement<ArrayOfMetricData>(_ArrayOfMetricData_QNAME, ArrayOfMetricData.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link KeywordLocation }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "KeywordLocation")
+    public JAXBElement<KeywordLocation> createKeywordLocation(KeywordLocation value) {
+        return new JAXBElement<KeywordLocation>(_KeywordLocation_QNAME, KeywordLocation.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AdApiError }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://adapi.microsoft.com", name = "AdApiError")
+    public JAXBElement<AdApiError> createAdApiError(AdApiError value) {
+        return new JAXBElement<AdApiError>(_AdApiError_QNAME, AdApiError.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link LocationCriterion }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "LocationCriterion")
+    public JAXBElement<LocationCriterion> createLocationCriterion(LocationCriterion value) {
+        return new JAXBElement<LocationCriterion>(_LocationCriterion_QNAME, LocationCriterion.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link LanguageSearchParameter }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "LanguageSearchParameter")
+    public JAXBElement<LanguageSearchParameter> createLanguageSearchParameter(LanguageSearchParameter value) {
+        return new JAXBElement<LanguageSearchParameter>(_LanguageSearchParameter_QNAME, LanguageSearchParameter.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link Collection }{@code <}{@link BidOpportunityType }{@code >}{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "BidOpportunityType")
+    @XmlJavaTypeAdapter(Adapter3 .class)
+    public JAXBElement<Collection<BidOpportunityType>> createBidOpportunityType(Collection<BidOpportunityType> value) {
+        return new JAXBElement<Collection<BidOpportunityType>>(_BidOpportunityType_QNAME, ((Class) Collection.class), null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link byte[]}{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://schemas.microsoft.com/2003/10/Serialization/", name = "base64Binary")
+    public JAXBElement<byte[]> createBase64Binary(byte[] value) {
+        return new JAXBElement<byte[]>(_Base64Binary_QNAME, byte[].class, null, ((byte[]) value));
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link CampaignEstimator }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "CampaignEstimator")
+    public JAXBElement<CampaignEstimator> createCampaignEstimator(CampaignEstimator value) {
+        return new JAXBElement<CampaignEstimator>(_CampaignEstimator_QNAME, CampaignEstimator.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfEstimatedPositionAndTraffic }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfEstimatedPositionAndTraffic")
+    public JAXBElement<ArrayOfEstimatedPositionAndTraffic> createArrayOfEstimatedPositionAndTraffic(ArrayOfEstimatedPositionAndTraffic value) {
+        return new JAXBElement<ArrayOfEstimatedPositionAndTraffic>(_ArrayOfEstimatedPositionAndTraffic_QNAME, ArrayOfEstimatedPositionAndTraffic.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link EntityType }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "EntityType")
+    public JAXBElement<EntityType> createEntityType(EntityType value) {
+        return new JAXBElement<EntityType>(_EntityType_QNAME, EntityType.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfAdGroupBidLandscapeInput }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfAdGroupBidLandscapeInput")
+    public JAXBElement<ArrayOfAdGroupBidLandscapeInput> createArrayOfAdGroupBidLandscapeInput(ArrayOfAdGroupBidLandscapeInput value) {
+        return new JAXBElement<ArrayOfAdGroupBidLandscapeInput>(_ArrayOfAdGroupBidLandscapeInput_QNAME, ArrayOfAdGroupBidLandscapeInput.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ExcludeAccountKeywordsSearchParameter }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ExcludeAccountKeywordsSearchParameter")
+    public JAXBElement<ExcludeAccountKeywordsSearchParameter> createExcludeAccountKeywordsSearchParameter(ExcludeAccountKeywordsSearchParameter value) {
+        return new JAXBElement<ExcludeAccountKeywordsSearchParameter>(_ExcludeAccountKeywordsSearchParameter_QNAME, ExcludeAccountKeywordsSearchParameter.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AdPosition }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "AdPosition")
+    public JAXBElement<AdPosition> createAdPosition(AdPosition value) {
+        return new JAXBElement<AdPosition>(_AdPosition_QNAME, AdPosition.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfSearchCountsByAttributes }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfSearchCountsByAttributes")
+    public JAXBElement<ArrayOfSearchCountsByAttributes> createArrayOfSearchCountsByAttributes(ArrayOfSearchCountsByAttributes value) {
+        return new JAXBElement<ArrayOfSearchCountsByAttributes>(_ArrayOfSearchCountsByAttributes_QNAME, ArrayOfSearchCountsByAttributes.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link SearchParameter }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "SearchParameter")
+    public JAXBElement<SearchParameter> createSearchParameter(SearchParameter value) {
+        return new JAXBElement<SearchParameter>(_SearchParameter_QNAME, SearchParameter.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link SearchVolumeSearchParameter }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "SearchVolumeSearchParameter")
+    public JAXBElement<SearchVolumeSearchParameter> createSearchVolumeSearchParameter(SearchVolumeSearchParameter value) {
+        return new JAXBElement<SearchVolumeSearchParameter>(_SearchVolumeSearchParameter_QNAME, SearchVolumeSearchParameter.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link Collection }{@code <}{@link AuctionInsightKpiAdditionalField }{@code >}{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "AuctionInsightKpiAdditionalField")
+    @XmlJavaTypeAdapter(Adapter2 .class)
+    public JAXBElement<Collection<AuctionInsightKpiAdditionalField>> createAuctionInsightKpiAdditionalField(Collection<AuctionInsightKpiAdditionalField> value) {
+        return new JAXBElement<Collection<AuctionInsightKpiAdditionalField>>(_AuctionInsightKpiAdditionalField_QNAME, ((Class) Collection.class), null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link KeywordEstimatedPosition }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "KeywordEstimatedPosition")
+    public JAXBElement<KeywordEstimatedPosition> createKeywordEstimatedPosition(KeywordEstimatedPosition value) {
+        return new JAXBElement<KeywordEstimatedPosition>(_KeywordEstimatedPosition_QNAME, KeywordEstimatedPosition.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link Calendar }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://schemas.microsoft.com/2003/10/Serialization/", name = "dateTime")
+    @XmlJavaTypeAdapter(Adapter1 .class)
+    public JAXBElement<Calendar> createDateTime(Calendar value) {
+        return new JAXBElement<Calendar>(_DateTime_QNAME, Calendar.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfLocationCriterion }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfLocationCriterion")
+    public JAXBElement<ArrayOfLocationCriterion> createArrayOfLocationCriterion(ArrayOfLocationCriterion value) {
+        return new JAXBElement<ArrayOfLocationCriterion>(_ArrayOfLocationCriterion_QNAME, ArrayOfLocationCriterion.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link KeywordEstimator }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "KeywordEstimator")
+    public JAXBElement<KeywordEstimator> createKeywordEstimator(KeywordEstimator value) {
+        return new JAXBElement<KeywordEstimator>(_KeywordEstimator_QNAME, KeywordEstimator.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfAutoApplyRecommendationsInfo }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfAutoApplyRecommendationsInfo")
+    public JAXBElement<ArrayOfAutoApplyRecommendationsInfo> createArrayOfAutoApplyRecommendationsInfo(ArrayOfAutoApplyRecommendationsInfo value) {
+        return new JAXBElement<ArrayOfAutoApplyRecommendationsInfo>(_ArrayOfAutoApplyRecommendationsInfo_QNAME, ArrayOfAutoApplyRecommendationsInfo.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AdGroupEstimator }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "AdGroupEstimator")
+    public JAXBElement<AdGroupEstimator> createAdGroupEstimator(AdGroupEstimator value) {
+        return new JAXBElement<AdGroupEstimator>(_AdGroupEstimator_QNAME, AdGroupEstimator.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link Char }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://schemas.microsoft.com/2003/10/Serialization/", name = "char")
+    public JAXBElement<Char> createChar(Char value) {
+        return new JAXBElement<Char>(_Char_QNAME, Char.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link DomainCategory }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "DomainCategory")
+    public JAXBElement<DomainCategory> createDomainCategory(DomainCategory value) {
+        return new JAXBElement<DomainCategory>(_DomainCategory_QNAME, DomainCategory.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link SuggestedBidSearchParameter }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "SuggestedBidSearchParameter")
+    public JAXBElement<SuggestedBidSearchParameter> createSuggestedBidSearchParameter(SuggestedBidSearchParameter value) {
+        return new JAXBElement<SuggestedBidSearchParameter>(_SuggestedBidSearchParameter_QNAME, SuggestedBidSearchParameter.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ParameterType }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ParameterType")
+    public JAXBElement<ParameterType> createParameterType(ParameterType value) {
+        return new JAXBElement<ParameterType>(_ParameterType_QNAME, ParameterType.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link Keyword }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "Keyword")
+    public JAXBElement<Keyword> createKeyword(Keyword value) {
+        return new JAXBElement<Keyword>(_Keyword_QNAME, Keyword.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link LocationSearchParameter }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "LocationSearchParameter")
+    public JAXBElement<LocationSearchParameter> createLocationSearchParameter(LocationSearchParameter value) {
+        return new JAXBElement<LocationSearchParameter>(_LocationSearchParameter_QNAME, LocationSearchParameter.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link KeywordDemographicResult }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "KeywordDemographicResult")
+    public JAXBElement<KeywordDemographicResult> createKeywordDemographicResult(KeywordDemographicResult value) {
+        return new JAXBElement<KeywordDemographicResult>(_KeywordDemographicResult_QNAME, KeywordDemographicResult.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfKeywordSuggestion }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfKeywordSuggestion")
+    public JAXBElement<ArrayOfKeywordSuggestion> createArrayOfKeywordSuggestion(ArrayOfKeywordSuggestion value) {
+        return new JAXBElement<ArrayOfKeywordSuggestion>(_ArrayOfKeywordSuggestion_QNAME, ArrayOfKeywordSuggestion.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link DayMonthAndYear }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "DayMonthAndYear")
+    public JAXBElement<DayMonthAndYear> createDayMonthAndYear(DayMonthAndYear value) {
+        return new JAXBElement<DayMonthAndYear>(_DayMonthAndYear_QNAME, DayMonthAndYear.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link UnsignedLong }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://schemas.microsoft.com/2003/10/Serialization/", name = "unsignedLong")
+    public JAXBElement<UnsignedLong> createUnsignedLong(UnsignedLong value) {
+        return new JAXBElement<UnsignedLong>(_UnsignedLong_QNAME, UnsignedLong.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfEstimatedBidAndTraffic }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfEstimatedBidAndTraffic")
+    public JAXBElement<ArrayOfEstimatedBidAndTraffic> createArrayOfEstimatedBidAndTraffic(ArrayOfEstimatedBidAndTraffic value) {
+        return new JAXBElement<ArrayOfEstimatedBidAndTraffic>(_ArrayOfEstimatedBidAndTraffic_QNAME, ArrayOfEstimatedBidAndTraffic.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link Integer }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://schemas.microsoft.com/2003/10/Serialization/", name = "unsignedShort")
+    public JAXBElement<Integer> createUnsignedShort(Integer value) {
+        return new JAXBElement<Integer>(_UnsignedShort_QNAME, Integer.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link BidOpportunity }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "BidOpportunity")
+    public JAXBElement<BidOpportunity> createBidOpportunity(BidOpportunity value) {
+        return new JAXBElement<BidOpportunity>(_BidOpportunity_QNAME, BidOpportunity.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfKeywordIdEstimatedBid }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfKeywordIdEstimatedBid")
+    public JAXBElement<ArrayOfKeywordIdEstimatedBid> createArrayOfKeywordIdEstimatedBid(ArrayOfKeywordIdEstimatedBid value) {
+        return new JAXBElement<ArrayOfKeywordIdEstimatedBid>(_ArrayOfKeywordIdEstimatedBid_QNAME, ArrayOfKeywordIdEstimatedBid.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link EntityDetail }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "EntityDetail")
+    public JAXBElement<EntityDetail> createEntityDetail(EntityDetail value) {
+        return new JAXBElement<EntityDetail>(_EntityDetail_QNAME, EntityDetail.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfBudgetOpportunity }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfBudgetOpportunity")
+    public JAXBElement<ArrayOfBudgetOpportunity> createArrayOfBudgetOpportunity(ArrayOfBudgetOpportunity value) {
+        return new JAXBElement<ArrayOfBudgetOpportunity>(_ArrayOfBudgetOpportunity_QNAME, ArrayOfBudgetOpportunity.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link BroadMatchSearchQueryKPI }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "BroadMatchSearchQueryKPI")
+    public JAXBElement<BroadMatchSearchQueryKPI> createBroadMatchSearchQueryKPI(BroadMatchSearchQueryKPI value) {
+        return new JAXBElement<BroadMatchSearchQueryKPI>(_BroadMatchSearchQueryKPI_QNAME, BroadMatchSearchQueryKPI.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link BudgetPoint }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "BudgetPoint")
+    public JAXBElement<BudgetPoint> createBudgetPoint(BudgetPoint value) {
+        return new JAXBElement<BudgetPoint>(_BudgetPoint_QNAME, BudgetPoint.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link KeywordIdeaCategory }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "KeywordIdeaCategory")
+    public JAXBElement<KeywordIdeaCategory> createKeywordIdeaCategory(KeywordIdeaCategory value) {
+        return new JAXBElement<KeywordIdeaCategory>(_KeywordIdeaCategory_QNAME, KeywordIdeaCategory.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link String }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "CustomerId")
+    public JAXBElement<String> createCustomerId(String value) {
+        return new JAXBElement<String>(_CustomerId_QNAME, String.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AdApiFaultDetail }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://adapi.microsoft.com", name = "AdApiFaultDetail")
+    public JAXBElement<AdApiFaultDetail> createAdApiFaultDetail(AdApiFaultDetail value) {
+        return new JAXBElement<AdApiFaultDetail>(_AdApiFaultDetail_QNAME, AdApiFaultDetail.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link Collection }{@code <}{@link KeywordOpportunityType }{@code >}{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "KeywordOpportunityType")
+    @XmlJavaTypeAdapter(Adapter4 .class)
+    public JAXBElement<Collection<KeywordOpportunityType>> createKeywordOpportunityType(Collection<KeywordOpportunityType> value) {
+        return new JAXBElement<Collection<KeywordOpportunityType>>(_KeywordOpportunityType_QNAME, ((Class) Collection.class), null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link KeywordHistoricalPerformance }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "KeywordHistoricalPerformance")
+    public JAXBElement<KeywordHistoricalPerformance> createKeywordHistoricalPerformance(KeywordHistoricalPerformance value) {
+        return new JAXBElement<KeywordHistoricalPerformance>(_KeywordHistoricalPerformance_QNAME, KeywordHistoricalPerformance.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ApplicationFault }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://adapi.microsoft.com", name = "ApplicationFault")
+    public JAXBElement<ApplicationFault> createApplicationFault(ApplicationFault value) {
+        return new JAXBElement<ApplicationFault>(_ApplicationFault_QNAME, ApplicationFault.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link BidLandscapePoint }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "BidLandscapePoint")
+    public JAXBElement<BidLandscapePoint> createBidLandscapePoint(BidLandscapePoint value) {
+        return new JAXBElement<BidLandscapePoint>(_BidLandscapePoint_QNAME, BidLandscapePoint.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link KeywordCategory }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "KeywordCategory")
+    public JAXBElement<KeywordCategory> createKeywordCategory(KeywordCategory value) {
+        return new JAXBElement<KeywordCategory>(_KeywordCategory_QNAME, KeywordCategory.class, null, value);
+    }
+
+    /**
      * Create an instance of {@link JAXBElement }{@code <}{@link Byte }{@code >}}
      * 
      */
@@ -3327,15 +3678,6 @@ public class ObjectFactory {
     @XmlElementDecl(namespace = "http://schemas.microsoft.com/2003/10/Serialization/", name = "double")
     public JAXBElement<Double> createDouble(Double value) {
         return new JAXBElement<Double>(_Double_QNAME, Double.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfAuctionSegment }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "https://bingads.microsoft.com/AdInsight/v13", name = "ArrayOfAuctionSegment")
-    public JAXBElement<ArrayOfAuctionSegment> createArrayOfAuctionSegment(ArrayOfAuctionSegment value) {
-        return new JAXBElement<ArrayOfAuctionSegment>(_ArrayOfAuctionSegment_QNAME, ArrayOfAuctionSegment.class, null, value);
     }
 
 }

--- a/proxies/com/microsoft/bingads/v13/adinsight/ParameterType.java
+++ b/proxies/com/microsoft/bingads/v13/adinsight/ParameterType.java
@@ -1,0 +1,54 @@
+
+package com.microsoft.bingads.v13.adinsight;
+
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java class for ParameterType.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>
+ * <pre>
+ * &lt;simpleType name="ParameterType">
+ *   &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string">
+ *     &lt;enumeration value="Text"/>
+ *     &lt;enumeration value="Url"/>
+ *     &lt;enumeration value="Entities"/>
+ *   &lt;/restriction>
+ * &lt;/simpleType>
+ * </pre>
+ * 
+ */
+@XmlType(name = "ParameterType")
+@XmlEnum
+public enum ParameterType {
+
+    @XmlEnumValue("Text")
+    TEXT("Text"),
+    @XmlEnumValue("Url")
+    URL("Url"),
+    @XmlEnumValue("Entities")
+    ENTITIES("Entities");
+    private final String value;
+
+    ParameterType(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    public static ParameterType fromValue(String v) {
+        for (ParameterType c: ParameterType.values()) {
+            if (c.value.equals(v)) {
+                return c;
+            }
+        }
+        throw new IllegalArgumentException(v);
+    }
+
+}

--- a/proxies/com/microsoft/bingads/v13/adinsight/PerformanceInsightsDetail.java
+++ b/proxies/com/microsoft/bingads/v13/adinsight/PerformanceInsightsDetail.java
@@ -1,0 +1,233 @@
+
+package com.microsoft.bingads.v13.adinsight;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlSchemaType;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java class for PerformanceInsightsDetail complex type.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ * 
+ * <pre>
+ * &lt;complexType name="PerformanceInsightsDetail">
+ *   &lt;complexContent>
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       &lt;sequence>
+ *         &lt;element name="EntityId" type="{http://www.w3.org/2001/XMLSchema}long" minOccurs="0"/>
+ *         &lt;element name="EntityType" type="{https://bingads.microsoft.com/AdInsight/v13}EntityType" minOccurs="0"/>
+ *         &lt;element name="KPIType" type="{https://bingads.microsoft.com/AdInsight/v13}KPIType" minOccurs="0"/>
+ *         &lt;element name="Date" type="{https://bingads.microsoft.com/AdInsight/v13}DayMonthAndYear" minOccurs="0"/>
+ *         &lt;element name="Description" type="{https://bingads.microsoft.com/AdInsight/v13}PerformanceInsightsMessage" minOccurs="0"/>
+ *         &lt;element name="RootCauses" type="{https://bingads.microsoft.com/AdInsight/v13}ArrayOfPerformanceInsightsMessage" minOccurs="0"/>
+ *         &lt;element name="Actions" type="{https://bingads.microsoft.com/AdInsight/v13}ArrayOfPerformanceInsightsMessage" minOccurs="0"/>
+ *       &lt;/sequence>
+ *     &lt;/restriction>
+ *   &lt;/complexContent>
+ * &lt;/complexType>
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "PerformanceInsightsDetail", propOrder = {
+    "entityId",
+    "entityType",
+    "kpiType",
+    "date",
+    "description",
+    "rootCauses",
+    "actions"
+})
+public class PerformanceInsightsDetail {
+
+    @XmlElement(name = "EntityId")
+    protected Long entityId;
+    @XmlElement(name = "EntityType")
+    @XmlSchemaType(name = "string")
+    protected EntityType entityType;
+    @XmlElement(name = "KPIType")
+    @XmlSchemaType(name = "string")
+    protected KPIType kpiType;
+    @XmlElement(name = "Date", nillable = true)
+    protected DayMonthAndYear date;
+    @XmlElement(name = "Description", nillable = true)
+    protected PerformanceInsightsMessage description;
+    @XmlElement(name = "RootCauses", nillable = true)
+    protected ArrayOfPerformanceInsightsMessage rootCauses;
+    @XmlElement(name = "Actions", nillable = true)
+    protected ArrayOfPerformanceInsightsMessage actions;
+
+    /**
+     * Gets the value of the entityId property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link Long }
+     *     
+     */
+    public Long getEntityId() {
+        return entityId;
+    }
+
+    /**
+     * Sets the value of the entityId property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link Long }
+     *     
+     */
+    public void setEntityId(Long value) {
+        this.entityId = value;
+    }
+
+    /**
+     * Gets the value of the entityType property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link EntityType }
+     *     
+     */
+    public EntityType getEntityType() {
+        return entityType;
+    }
+
+    /**
+     * Sets the value of the entityType property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link EntityType }
+     *     
+     */
+    public void setEntityType(EntityType value) {
+        this.entityType = value;
+    }
+
+    /**
+     * Gets the value of the kpiType property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link KPIType }
+     *     
+     */
+    public KPIType getKPIType() {
+        return kpiType;
+    }
+
+    /**
+     * Sets the value of the kpiType property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link KPIType }
+     *     
+     */
+    public void setKPIType(KPIType value) {
+        this.kpiType = value;
+    }
+
+    /**
+     * Gets the value of the date property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link DayMonthAndYear }
+     *     
+     */
+    public DayMonthAndYear getDate() {
+        return date;
+    }
+
+    /**
+     * Sets the value of the date property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link DayMonthAndYear }
+     *     
+     */
+    public void setDate(DayMonthAndYear value) {
+        this.date = value;
+    }
+
+    /**
+     * Gets the value of the description property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link PerformanceInsightsMessage }
+     *     
+     */
+    public PerformanceInsightsMessage getDescription() {
+        return description;
+    }
+
+    /**
+     * Sets the value of the description property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link PerformanceInsightsMessage }
+     *     
+     */
+    public void setDescription(PerformanceInsightsMessage value) {
+        this.description = value;
+    }
+
+    /**
+     * Gets the value of the rootCauses property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link ArrayOfPerformanceInsightsMessage }
+     *     
+     */
+    public ArrayOfPerformanceInsightsMessage getRootCauses() {
+        return rootCauses;
+    }
+
+    /**
+     * Sets the value of the rootCauses property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link ArrayOfPerformanceInsightsMessage }
+     *     
+     */
+    public void setRootCauses(ArrayOfPerformanceInsightsMessage value) {
+        this.rootCauses = value;
+    }
+
+    /**
+     * Gets the value of the actions property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link ArrayOfPerformanceInsightsMessage }
+     *     
+     */
+    public ArrayOfPerformanceInsightsMessage getActions() {
+        return actions;
+    }
+
+    /**
+     * Sets the value of the actions property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link ArrayOfPerformanceInsightsMessage }
+     *     
+     */
+    public void setActions(ArrayOfPerformanceInsightsMessage value) {
+        this.actions = value;
+    }
+
+}

--- a/proxies/com/microsoft/bingads/v13/adinsight/PerformanceInsightsEntityType.java
+++ b/proxies/com/microsoft/bingads/v13/adinsight/PerformanceInsightsEntityType.java
@@ -1,0 +1,66 @@
+
+package com.microsoft.bingads.v13.adinsight;
+
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java class for PerformanceInsightsEntityType.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>
+ * <pre>
+ * &lt;simpleType name="PerformanceInsightsEntityType">
+ *   &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string">
+ *     &lt;enumeration value="Account"/>
+ *     &lt;enumeration value="Campaign"/>
+ *     &lt;enumeration value="AdGroup"/>
+ *     &lt;enumeration value="Keyword"/>
+ *     &lt;enumeration value="ProductGroup"/>
+ *     &lt;enumeration value="SearchTerm"/>
+ *     &lt;enumeration value="Website"/>
+ *   &lt;/restriction>
+ * &lt;/simpleType>
+ * </pre>
+ * 
+ */
+@XmlType(name = "PerformanceInsightsEntityType")
+@XmlEnum
+public enum PerformanceInsightsEntityType {
+
+    @XmlEnumValue("Account")
+    ACCOUNT("Account"),
+    @XmlEnumValue("Campaign")
+    CAMPAIGN("Campaign"),
+    @XmlEnumValue("AdGroup")
+    AD_GROUP("AdGroup"),
+    @XmlEnumValue("Keyword")
+    KEYWORD("Keyword"),
+    @XmlEnumValue("ProductGroup")
+    PRODUCT_GROUP("ProductGroup"),
+    @XmlEnumValue("SearchTerm")
+    SEARCH_TERM("SearchTerm"),
+    @XmlEnumValue("Website")
+    WEBSITE("Website");
+    private final String value;
+
+    PerformanceInsightsEntityType(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    public static PerformanceInsightsEntityType fromValue(String v) {
+        for (PerformanceInsightsEntityType c: PerformanceInsightsEntityType.values()) {
+            if (c.value.equals(v)) {
+                return c;
+            }
+        }
+        throw new IllegalArgumentException(v);
+    }
+
+}

--- a/proxies/com/microsoft/bingads/v13/adinsight/PerformanceInsightsMessage.java
+++ b/proxies/com/microsoft/bingads/v13/adinsight/PerformanceInsightsMessage.java
@@ -1,0 +1,120 @@
+
+package com.microsoft.bingads.v13.adinsight;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlSchemaType;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java class for PerformanceInsightsMessage complex type.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ * 
+ * <pre>
+ * &lt;complexType name="PerformanceInsightsMessage">
+ *   &lt;complexContent>
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       &lt;sequence>
+ *         &lt;element name="TemplateId" type="{https://bingads.microsoft.com/AdInsight/v13}PerformanceInsightsMessageTemplateId" minOccurs="0"/>
+ *         &lt;element name="Parameters" type="{https://bingads.microsoft.com/AdInsight/v13}ArrayOfPerformanceInsightsMessageParameter" minOccurs="0"/>
+ *         &lt;element name="IndentationLevel" type="{http://www.w3.org/2001/XMLSchema}int" minOccurs="0"/>
+ *       &lt;/sequence>
+ *     &lt;/restriction>
+ *   &lt;/complexContent>
+ * &lt;/complexType>
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "PerformanceInsightsMessage", propOrder = {
+    "templateId",
+    "parameters",
+    "indentationLevel"
+})
+public class PerformanceInsightsMessage {
+
+    @XmlElement(name = "TemplateId")
+    @XmlSchemaType(name = "string")
+    protected PerformanceInsightsMessageTemplateId templateId;
+    @XmlElement(name = "Parameters", nillable = true)
+    protected ArrayOfPerformanceInsightsMessageParameter parameters;
+    @XmlElement(name = "IndentationLevel")
+    protected Integer indentationLevel;
+
+    /**
+     * Gets the value of the templateId property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link PerformanceInsightsMessageTemplateId }
+     *     
+     */
+    public PerformanceInsightsMessageTemplateId getTemplateId() {
+        return templateId;
+    }
+
+    /**
+     * Sets the value of the templateId property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link PerformanceInsightsMessageTemplateId }
+     *     
+     */
+    public void setTemplateId(PerformanceInsightsMessageTemplateId value) {
+        this.templateId = value;
+    }
+
+    /**
+     * Gets the value of the parameters property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link ArrayOfPerformanceInsightsMessageParameter }
+     *     
+     */
+    public ArrayOfPerformanceInsightsMessageParameter getParameters() {
+        return parameters;
+    }
+
+    /**
+     * Sets the value of the parameters property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link ArrayOfPerformanceInsightsMessageParameter }
+     *     
+     */
+    public void setParameters(ArrayOfPerformanceInsightsMessageParameter value) {
+        this.parameters = value;
+    }
+
+    /**
+     * Gets the value of the indentationLevel property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link Integer }
+     *     
+     */
+    public Integer getIndentationLevel() {
+        return indentationLevel;
+    }
+
+    /**
+     * Sets the value of the indentationLevel property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link Integer }
+     *     
+     */
+    public void setIndentationLevel(Integer value) {
+        this.indentationLevel = value;
+    }
+
+}

--- a/proxies/com/microsoft/bingads/v13/adinsight/PerformanceInsightsMessageParameter.java
+++ b/proxies/com/microsoft/bingads/v13/adinsight/PerformanceInsightsMessageParameter.java
@@ -1,0 +1,70 @@
+
+package com.microsoft.bingads.v13.adinsight;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlSchemaType;
+import javax.xml.bind.annotation.XmlSeeAlso;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java class for PerformanceInsightsMessageParameter complex type.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ * 
+ * <pre>
+ * &lt;complexType name="PerformanceInsightsMessageParameter">
+ *   &lt;complexContent>
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       &lt;sequence>
+ *         &lt;element name="Type" type="{https://bingads.microsoft.com/AdInsight/v13}ParameterType" minOccurs="0"/>
+ *       &lt;/sequence>
+ *     &lt;/restriction>
+ *   &lt;/complexContent>
+ * &lt;/complexType>
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "PerformanceInsightsMessageParameter", propOrder = {
+    "type"
+})
+@XmlSeeAlso({
+    EntityParameter.class,
+    TextParameter.class,
+    UrlParameter.class
+})
+public class PerformanceInsightsMessageParameter {
+
+    @XmlElement(name = "Type")
+    @XmlSchemaType(name = "string")
+    protected ParameterType type;
+
+    /**
+     * Gets the value of the type property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link ParameterType }
+     *     
+     */
+    public ParameterType getType() {
+        return type;
+    }
+
+    /**
+     * Sets the value of the type property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link ParameterType }
+     *     
+     */
+    public void setType(ParameterType value) {
+        this.type = value;
+    }
+
+}

--- a/proxies/com/microsoft/bingads/v13/adinsight/PerformanceInsightsMessageTemplateId.java
+++ b/proxies/com/microsoft/bingads/v13/adinsight/PerformanceInsightsMessageTemplateId.java
@@ -1,0 +1,366 @@
+
+package com.microsoft.bingads.v13.adinsight;
+
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java class for PerformanceInsightsMessageTemplateId.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>
+ * <pre>
+ * &lt;simpleType name="PerformanceInsightsMessageTemplateId">
+ *   &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string">
+ *     &lt;enumeration value="FluxImprIncreaseAcct"/>
+ *     &lt;enumeration value="FluxImprDecreaseAcct"/>
+ *     &lt;enumeration value="FluxImprIncreaseInfinityAcct"/>
+ *     &lt;enumeration value="FluxImprIncreaseAcctPrevDay"/>
+ *     &lt;enumeration value="FluxImprDecreaseAcctPrevDay"/>
+ *     &lt;enumeration value="FluxImprIncreaseInfinityAcctPrevDay"/>
+ *     &lt;enumeration value="FluxClickIncreaseAcct"/>
+ *     &lt;enumeration value="FluxClickDecreaseAcct"/>
+ *     &lt;enumeration value="FluxClickIncreaseInfinityAcct"/>
+ *     &lt;enumeration value="FluxClickIncreaseAcctPrevDay"/>
+ *     &lt;enumeration value="FluxClickDecreaseAcctPrevDay"/>
+ *     &lt;enumeration value="FluxClickIncreaseInfinityAcctPrevDay"/>
+ *     &lt;enumeration value="FluxCostIncreaseAcct"/>
+ *     &lt;enumeration value="FluxCostDecreaseAcct"/>
+ *     &lt;enumeration value="FluxCostIncreaseInfinityAcct"/>
+ *     &lt;enumeration value="FluxCostIncreaseAcctPrevDay"/>
+ *     &lt;enumeration value="FluxCostDecreaseAcctPrevDay"/>
+ *     &lt;enumeration value="FluxCostIncreaseInfinityAcctPrevDay"/>
+ *     &lt;enumeration value="FluxImprIncreaseCampaign"/>
+ *     &lt;enumeration value="FluxImprDecreaseCampaign"/>
+ *     &lt;enumeration value="FluxImprIncreaseInfinityCampaign"/>
+ *     &lt;enumeration value="FluxImprIncreaseCampaignPrevDay"/>
+ *     &lt;enumeration value="FluxImprDecreaseCampaignPrevDay"/>
+ *     &lt;enumeration value="FluxImprIncreaseInfinityCampaignPrevDay"/>
+ *     &lt;enumeration value="FluxClickIncreaseCampaign"/>
+ *     &lt;enumeration value="FluxClickDecreaseCampaign"/>
+ *     &lt;enumeration value="FluxClickIncreaseInfinityCampaign"/>
+ *     &lt;enumeration value="FluxClickIncreaseCampaignPrevDay"/>
+ *     &lt;enumeration value="FluxClickDecreaseCampaignPrevDay"/>
+ *     &lt;enumeration value="FluxClickIncreaseInfinityCampaignPrevDay"/>
+ *     &lt;enumeration value="FluxCostIncreaseCampaign"/>
+ *     &lt;enumeration value="FluxCostDecreaseCampaign"/>
+ *     &lt;enumeration value="FluxCostIncreaseInfinityCampaign"/>
+ *     &lt;enumeration value="FluxCostIncreaseCampaignPrevDay"/>
+ *     &lt;enumeration value="FluxCostDecreaseCampaignPrevDay"/>
+ *     &lt;enumeration value="FluxCostIncreaseInfinityCampaignPrevDay"/>
+ *     &lt;enumeration value="FluxConversionDecreaseAcct"/>
+ *     &lt;enumeration value="FluxConversionZeroAcct"/>
+ *     &lt;enumeration value="RCAudienceIncrease"/>
+ *     &lt;enumeration value="RCAudienceDecrease"/>
+ *     &lt;enumeration value="RCBidIncrease"/>
+ *     &lt;enumeration value="RCBidDecrease"/>
+ *     &lt;enumeration value="RCBudgetIncrease"/>
+ *     &lt;enumeration value="RCBudgetDecrease"/>
+ *     &lt;enumeration value="RCClickIncrease"/>
+ *     &lt;enumeration value="RCClickDecrease"/>
+ *     &lt;enumeration value="RCConversionGoalIssue"/>
+ *     &lt;enumeration value="RCDeviceTargetingBidChange"/>
+ *     &lt;enumeration value="RCEditorialApproval"/>
+ *     &lt;enumeration value="RCEditorialDisapproval"/>
+ *     &lt;enumeration value="RCEntityAdditionWithCount"/>
+ *     &lt;enumeration value="RCEntityDeletionWithCount"/>
+ *     &lt;enumeration value="RCEntityPauseWithCount"/>
+ *     &lt;enumeration value="RCEntityUnpauseWithCount"/>
+ *     &lt;enumeration value="RCMoreCompetitive"/>
+ *     &lt;enumeration value="RCNetworkLessRestrict"/>
+ *     &lt;enumeration value="RCNetworkMoreRestrict"/>
+ *     &lt;enumeration value="RCPaymentIssueInvoiceAccountPaused"/>
+ *     &lt;enumeration value="RCPaymentIssueInvoiceAccountOnHold"/>
+ *     &lt;enumeration value="RCPaymentIssuePrepayAccountPaused"/>
+ *     &lt;enumeration value="RCPaymentIssueThresholdAccountOnHold"/>
+ *     &lt;enumeration value="RCPaymentIssueYesterday"/>
+ *     &lt;enumeration value="RCSearchTermIncrease"/>
+ *     &lt;enumeration value="RCSearchTermIncreaseClick"/>
+ *     &lt;enumeration value="RCSearchTermDecrease"/>
+ *     &lt;enumeration value="RCSearchTermDecreaseClick"/>
+ *     &lt;enumeration value="RCSearchTermCompetitionIncrease"/>
+ *     &lt;enumeration value="RCSearchTermCompetitionIncreaseClick"/>
+ *     &lt;enumeration value="RCSearchTermCompetitionDecrease"/>
+ *     &lt;enumeration value="RCSearchTermCompetitionDecreaseClick"/>
+ *     &lt;enumeration value="RCSingleCampaignAddition"/>
+ *     &lt;enumeration value="RCSingleCampaignPause"/>
+ *     &lt;enumeration value="RCSingleCampaignUnpause"/>
+ *     &lt;enumeration value="RCSingleCampaignBudgetIncrease"/>
+ *     &lt;enumeration value="RCSingleCampaignBudgetDecrease"/>
+ *     &lt;enumeration value="RCSingleCampaignDeviceTargetingBidChange"/>
+ *     &lt;enumeration value="RCStrongerCompetitorAdQuality"/>
+ *     &lt;enumeration value="RCStrongerCompetitorBid"/>
+ *     &lt;enumeration value="RCSyndTrafficIncrease"/>
+ *     &lt;enumeration value="RCSyndTrafficDecrease"/>
+ *     &lt;enumeration value="ActAdsOppr"/>
+ *     &lt;enumeration value="ActAllAvailableOppr"/>
+ *     &lt;enumeration value="ActBMAdoptionOppr"/>
+ *     &lt;enumeration value="ActBMMKeywordOppr"/>
+ *     &lt;enumeration value="ActCampaignContextKeywordOppr"/>
+ *     &lt;enumeration value="ActCheckPublisherWebsite"/>
+ *     &lt;enumeration value="ActCompetitionAuctionInsight"/>
+ *     &lt;enumeration value="ActCompetitiveBudgetOppr"/>
+ *     &lt;enumeration value="ActCompetitiveKeywordOppr"/>
+ *     &lt;enumeration value="ActCompetitiveLocationTargetOppr"/>
+ *     &lt;enumeration value="ActCTRQualityBundle"/>
+ *     &lt;enumeration value="ActEditorialReviewProcess"/>
+ *     &lt;enumeration value="ActFixConversionGoalSettingOppr"/>
+ *     &lt;enumeration value="ActFixConversionTrackingOppr"/>
+ *     &lt;enumeration value="ActGeneralBudgetOppr"/>
+ *     &lt;enumeration value="ActNewConversionGoalOppr"/>
+ *     &lt;enumeration value="ActInvoiceAccountPaused"/>
+ *     &lt;enumeration value="ActInvoiceAccountOnHold"/>
+ *     &lt;enumeration value="ActPrepayAccountPaused"/>
+ *     &lt;enumeration value="ActReallocateBudgetOppr"/>
+ *     &lt;enumeration value="ActRepairKeywordsOppr"/>
+ *     &lt;enumeration value="ActRSAOppr"/>
+ *     &lt;enumeration value="ActSearchTerm"/>
+ *     &lt;enumeration value="ActSetupConversionTrackingOppr"/>
+ *     &lt;enumeration value="ActSiteLinkOppr"/>
+ *     &lt;enumeration value="ActThresholdAccountOnHold"/>
+ *     &lt;enumeration value="ActWebsiteExclusion"/>
+ *   &lt;/restriction>
+ * &lt;/simpleType>
+ * </pre>
+ * 
+ */
+@XmlType(name = "PerformanceInsightsMessageTemplateId")
+@XmlEnum
+public enum PerformanceInsightsMessageTemplateId {
+
+    @XmlEnumValue("FluxImprIncreaseAcct")
+    FLUX_IMPR_INCREASE_ACCT("FluxImprIncreaseAcct"),
+    @XmlEnumValue("FluxImprDecreaseAcct")
+    FLUX_IMPR_DECREASE_ACCT("FluxImprDecreaseAcct"),
+    @XmlEnumValue("FluxImprIncreaseInfinityAcct")
+    FLUX_IMPR_INCREASE_INFINITY_ACCT("FluxImprIncreaseInfinityAcct"),
+    @XmlEnumValue("FluxImprIncreaseAcctPrevDay")
+    FLUX_IMPR_INCREASE_ACCT_PREV_DAY("FluxImprIncreaseAcctPrevDay"),
+    @XmlEnumValue("FluxImprDecreaseAcctPrevDay")
+    FLUX_IMPR_DECREASE_ACCT_PREV_DAY("FluxImprDecreaseAcctPrevDay"),
+    @XmlEnumValue("FluxImprIncreaseInfinityAcctPrevDay")
+    FLUX_IMPR_INCREASE_INFINITY_ACCT_PREV_DAY("FluxImprIncreaseInfinityAcctPrevDay"),
+    @XmlEnumValue("FluxClickIncreaseAcct")
+    FLUX_CLICK_INCREASE_ACCT("FluxClickIncreaseAcct"),
+    @XmlEnumValue("FluxClickDecreaseAcct")
+    FLUX_CLICK_DECREASE_ACCT("FluxClickDecreaseAcct"),
+    @XmlEnumValue("FluxClickIncreaseInfinityAcct")
+    FLUX_CLICK_INCREASE_INFINITY_ACCT("FluxClickIncreaseInfinityAcct"),
+    @XmlEnumValue("FluxClickIncreaseAcctPrevDay")
+    FLUX_CLICK_INCREASE_ACCT_PREV_DAY("FluxClickIncreaseAcctPrevDay"),
+    @XmlEnumValue("FluxClickDecreaseAcctPrevDay")
+    FLUX_CLICK_DECREASE_ACCT_PREV_DAY("FluxClickDecreaseAcctPrevDay"),
+    @XmlEnumValue("FluxClickIncreaseInfinityAcctPrevDay")
+    FLUX_CLICK_INCREASE_INFINITY_ACCT_PREV_DAY("FluxClickIncreaseInfinityAcctPrevDay"),
+    @XmlEnumValue("FluxCostIncreaseAcct")
+    FLUX_COST_INCREASE_ACCT("FluxCostIncreaseAcct"),
+    @XmlEnumValue("FluxCostDecreaseAcct")
+    FLUX_COST_DECREASE_ACCT("FluxCostDecreaseAcct"),
+    @XmlEnumValue("FluxCostIncreaseInfinityAcct")
+    FLUX_COST_INCREASE_INFINITY_ACCT("FluxCostIncreaseInfinityAcct"),
+    @XmlEnumValue("FluxCostIncreaseAcctPrevDay")
+    FLUX_COST_INCREASE_ACCT_PREV_DAY("FluxCostIncreaseAcctPrevDay"),
+    @XmlEnumValue("FluxCostDecreaseAcctPrevDay")
+    FLUX_COST_DECREASE_ACCT_PREV_DAY("FluxCostDecreaseAcctPrevDay"),
+    @XmlEnumValue("FluxCostIncreaseInfinityAcctPrevDay")
+    FLUX_COST_INCREASE_INFINITY_ACCT_PREV_DAY("FluxCostIncreaseInfinityAcctPrevDay"),
+    @XmlEnumValue("FluxImprIncreaseCampaign")
+    FLUX_IMPR_INCREASE_CAMPAIGN("FluxImprIncreaseCampaign"),
+    @XmlEnumValue("FluxImprDecreaseCampaign")
+    FLUX_IMPR_DECREASE_CAMPAIGN("FluxImprDecreaseCampaign"),
+    @XmlEnumValue("FluxImprIncreaseInfinityCampaign")
+    FLUX_IMPR_INCREASE_INFINITY_CAMPAIGN("FluxImprIncreaseInfinityCampaign"),
+    @XmlEnumValue("FluxImprIncreaseCampaignPrevDay")
+    FLUX_IMPR_INCREASE_CAMPAIGN_PREV_DAY("FluxImprIncreaseCampaignPrevDay"),
+    @XmlEnumValue("FluxImprDecreaseCampaignPrevDay")
+    FLUX_IMPR_DECREASE_CAMPAIGN_PREV_DAY("FluxImprDecreaseCampaignPrevDay"),
+    @XmlEnumValue("FluxImprIncreaseInfinityCampaignPrevDay")
+    FLUX_IMPR_INCREASE_INFINITY_CAMPAIGN_PREV_DAY("FluxImprIncreaseInfinityCampaignPrevDay"),
+    @XmlEnumValue("FluxClickIncreaseCampaign")
+    FLUX_CLICK_INCREASE_CAMPAIGN("FluxClickIncreaseCampaign"),
+    @XmlEnumValue("FluxClickDecreaseCampaign")
+    FLUX_CLICK_DECREASE_CAMPAIGN("FluxClickDecreaseCampaign"),
+    @XmlEnumValue("FluxClickIncreaseInfinityCampaign")
+    FLUX_CLICK_INCREASE_INFINITY_CAMPAIGN("FluxClickIncreaseInfinityCampaign"),
+    @XmlEnumValue("FluxClickIncreaseCampaignPrevDay")
+    FLUX_CLICK_INCREASE_CAMPAIGN_PREV_DAY("FluxClickIncreaseCampaignPrevDay"),
+    @XmlEnumValue("FluxClickDecreaseCampaignPrevDay")
+    FLUX_CLICK_DECREASE_CAMPAIGN_PREV_DAY("FluxClickDecreaseCampaignPrevDay"),
+    @XmlEnumValue("FluxClickIncreaseInfinityCampaignPrevDay")
+    FLUX_CLICK_INCREASE_INFINITY_CAMPAIGN_PREV_DAY("FluxClickIncreaseInfinityCampaignPrevDay"),
+    @XmlEnumValue("FluxCostIncreaseCampaign")
+    FLUX_COST_INCREASE_CAMPAIGN("FluxCostIncreaseCampaign"),
+    @XmlEnumValue("FluxCostDecreaseCampaign")
+    FLUX_COST_DECREASE_CAMPAIGN("FluxCostDecreaseCampaign"),
+    @XmlEnumValue("FluxCostIncreaseInfinityCampaign")
+    FLUX_COST_INCREASE_INFINITY_CAMPAIGN("FluxCostIncreaseInfinityCampaign"),
+    @XmlEnumValue("FluxCostIncreaseCampaignPrevDay")
+    FLUX_COST_INCREASE_CAMPAIGN_PREV_DAY("FluxCostIncreaseCampaignPrevDay"),
+    @XmlEnumValue("FluxCostDecreaseCampaignPrevDay")
+    FLUX_COST_DECREASE_CAMPAIGN_PREV_DAY("FluxCostDecreaseCampaignPrevDay"),
+    @XmlEnumValue("FluxCostIncreaseInfinityCampaignPrevDay")
+    FLUX_COST_INCREASE_INFINITY_CAMPAIGN_PREV_DAY("FluxCostIncreaseInfinityCampaignPrevDay"),
+    @XmlEnumValue("FluxConversionDecreaseAcct")
+    FLUX_CONVERSION_DECREASE_ACCT("FluxConversionDecreaseAcct"),
+    @XmlEnumValue("FluxConversionZeroAcct")
+    FLUX_CONVERSION_ZERO_ACCT("FluxConversionZeroAcct"),
+    @XmlEnumValue("RCAudienceIncrease")
+    RC_AUDIENCE_INCREASE("RCAudienceIncrease"),
+    @XmlEnumValue("RCAudienceDecrease")
+    RC_AUDIENCE_DECREASE("RCAudienceDecrease"),
+    @XmlEnumValue("RCBidIncrease")
+    RC_BID_INCREASE("RCBidIncrease"),
+    @XmlEnumValue("RCBidDecrease")
+    RC_BID_DECREASE("RCBidDecrease"),
+    @XmlEnumValue("RCBudgetIncrease")
+    RC_BUDGET_INCREASE("RCBudgetIncrease"),
+    @XmlEnumValue("RCBudgetDecrease")
+    RC_BUDGET_DECREASE("RCBudgetDecrease"),
+    @XmlEnumValue("RCClickIncrease")
+    RC_CLICK_INCREASE("RCClickIncrease"),
+    @XmlEnumValue("RCClickDecrease")
+    RC_CLICK_DECREASE("RCClickDecrease"),
+    @XmlEnumValue("RCConversionGoalIssue")
+    RC_CONVERSION_GOAL_ISSUE("RCConversionGoalIssue"),
+    @XmlEnumValue("RCDeviceTargetingBidChange")
+    RC_DEVICE_TARGETING_BID_CHANGE("RCDeviceTargetingBidChange"),
+    @XmlEnumValue("RCEditorialApproval")
+    RC_EDITORIAL_APPROVAL("RCEditorialApproval"),
+    @XmlEnumValue("RCEditorialDisapproval")
+    RC_EDITORIAL_DISAPPROVAL("RCEditorialDisapproval"),
+    @XmlEnumValue("RCEntityAdditionWithCount")
+    RC_ENTITY_ADDITION_WITH_COUNT("RCEntityAdditionWithCount"),
+    @XmlEnumValue("RCEntityDeletionWithCount")
+    RC_ENTITY_DELETION_WITH_COUNT("RCEntityDeletionWithCount"),
+    @XmlEnumValue("RCEntityPauseWithCount")
+    RC_ENTITY_PAUSE_WITH_COUNT("RCEntityPauseWithCount"),
+    @XmlEnumValue("RCEntityUnpauseWithCount")
+    RC_ENTITY_UNPAUSE_WITH_COUNT("RCEntityUnpauseWithCount"),
+    @XmlEnumValue("RCMoreCompetitive")
+    RC_MORE_COMPETITIVE("RCMoreCompetitive"),
+    @XmlEnumValue("RCNetworkLessRestrict")
+    RC_NETWORK_LESS_RESTRICT("RCNetworkLessRestrict"),
+    @XmlEnumValue("RCNetworkMoreRestrict")
+    RC_NETWORK_MORE_RESTRICT("RCNetworkMoreRestrict"),
+    @XmlEnumValue("RCPaymentIssueInvoiceAccountPaused")
+    RC_PAYMENT_ISSUE_INVOICE_ACCOUNT_PAUSED("RCPaymentIssueInvoiceAccountPaused"),
+    @XmlEnumValue("RCPaymentIssueInvoiceAccountOnHold")
+    RC_PAYMENT_ISSUE_INVOICE_ACCOUNT_ON_HOLD("RCPaymentIssueInvoiceAccountOnHold"),
+    @XmlEnumValue("RCPaymentIssuePrepayAccountPaused")
+    RC_PAYMENT_ISSUE_PREPAY_ACCOUNT_PAUSED("RCPaymentIssuePrepayAccountPaused"),
+    @XmlEnumValue("RCPaymentIssueThresholdAccountOnHold")
+    RC_PAYMENT_ISSUE_THRESHOLD_ACCOUNT_ON_HOLD("RCPaymentIssueThresholdAccountOnHold"),
+    @XmlEnumValue("RCPaymentIssueYesterday")
+    RC_PAYMENT_ISSUE_YESTERDAY("RCPaymentIssueYesterday"),
+    @XmlEnumValue("RCSearchTermIncrease")
+    RC_SEARCH_TERM_INCREASE("RCSearchTermIncrease"),
+    @XmlEnumValue("RCSearchTermIncreaseClick")
+    RC_SEARCH_TERM_INCREASE_CLICK("RCSearchTermIncreaseClick"),
+    @XmlEnumValue("RCSearchTermDecrease")
+    RC_SEARCH_TERM_DECREASE("RCSearchTermDecrease"),
+    @XmlEnumValue("RCSearchTermDecreaseClick")
+    RC_SEARCH_TERM_DECREASE_CLICK("RCSearchTermDecreaseClick"),
+    @XmlEnumValue("RCSearchTermCompetitionIncrease")
+    RC_SEARCH_TERM_COMPETITION_INCREASE("RCSearchTermCompetitionIncrease"),
+    @XmlEnumValue("RCSearchTermCompetitionIncreaseClick")
+    RC_SEARCH_TERM_COMPETITION_INCREASE_CLICK("RCSearchTermCompetitionIncreaseClick"),
+    @XmlEnumValue("RCSearchTermCompetitionDecrease")
+    RC_SEARCH_TERM_COMPETITION_DECREASE("RCSearchTermCompetitionDecrease"),
+    @XmlEnumValue("RCSearchTermCompetitionDecreaseClick")
+    RC_SEARCH_TERM_COMPETITION_DECREASE_CLICK("RCSearchTermCompetitionDecreaseClick"),
+    @XmlEnumValue("RCSingleCampaignAddition")
+    RC_SINGLE_CAMPAIGN_ADDITION("RCSingleCampaignAddition"),
+    @XmlEnumValue("RCSingleCampaignPause")
+    RC_SINGLE_CAMPAIGN_PAUSE("RCSingleCampaignPause"),
+    @XmlEnumValue("RCSingleCampaignUnpause")
+    RC_SINGLE_CAMPAIGN_UNPAUSE("RCSingleCampaignUnpause"),
+    @XmlEnumValue("RCSingleCampaignBudgetIncrease")
+    RC_SINGLE_CAMPAIGN_BUDGET_INCREASE("RCSingleCampaignBudgetIncrease"),
+    @XmlEnumValue("RCSingleCampaignBudgetDecrease")
+    RC_SINGLE_CAMPAIGN_BUDGET_DECREASE("RCSingleCampaignBudgetDecrease"),
+    @XmlEnumValue("RCSingleCampaignDeviceTargetingBidChange")
+    RC_SINGLE_CAMPAIGN_DEVICE_TARGETING_BID_CHANGE("RCSingleCampaignDeviceTargetingBidChange"),
+    @XmlEnumValue("RCStrongerCompetitorAdQuality")
+    RC_STRONGER_COMPETITOR_AD_QUALITY("RCStrongerCompetitorAdQuality"),
+    @XmlEnumValue("RCStrongerCompetitorBid")
+    RC_STRONGER_COMPETITOR_BID("RCStrongerCompetitorBid"),
+    @XmlEnumValue("RCSyndTrafficIncrease")
+    RC_SYND_TRAFFIC_INCREASE("RCSyndTrafficIncrease"),
+    @XmlEnumValue("RCSyndTrafficDecrease")
+    RC_SYND_TRAFFIC_DECREASE("RCSyndTrafficDecrease"),
+    @XmlEnumValue("ActAdsOppr")
+    ACT_ADS_OPPR("ActAdsOppr"),
+    @XmlEnumValue("ActAllAvailableOppr")
+    ACT_ALL_AVAILABLE_OPPR("ActAllAvailableOppr"),
+    @XmlEnumValue("ActBMAdoptionOppr")
+    ACT_BM_ADOPTION_OPPR("ActBMAdoptionOppr"),
+    @XmlEnumValue("ActBMMKeywordOppr")
+    ACT_BMM_KEYWORD_OPPR("ActBMMKeywordOppr"),
+    @XmlEnumValue("ActCampaignContextKeywordOppr")
+    ACT_CAMPAIGN_CONTEXT_KEYWORD_OPPR("ActCampaignContextKeywordOppr"),
+    @XmlEnumValue("ActCheckPublisherWebsite")
+    ACT_CHECK_PUBLISHER_WEBSITE("ActCheckPublisherWebsite"),
+    @XmlEnumValue("ActCompetitionAuctionInsight")
+    ACT_COMPETITION_AUCTION_INSIGHT("ActCompetitionAuctionInsight"),
+    @XmlEnumValue("ActCompetitiveBudgetOppr")
+    ACT_COMPETITIVE_BUDGET_OPPR("ActCompetitiveBudgetOppr"),
+    @XmlEnumValue("ActCompetitiveKeywordOppr")
+    ACT_COMPETITIVE_KEYWORD_OPPR("ActCompetitiveKeywordOppr"),
+    @XmlEnumValue("ActCompetitiveLocationTargetOppr")
+    ACT_COMPETITIVE_LOCATION_TARGET_OPPR("ActCompetitiveLocationTargetOppr"),
+    @XmlEnumValue("ActCTRQualityBundle")
+    ACT_CTR_QUALITY_BUNDLE("ActCTRQualityBundle"),
+    @XmlEnumValue("ActEditorialReviewProcess")
+    ACT_EDITORIAL_REVIEW_PROCESS("ActEditorialReviewProcess"),
+    @XmlEnumValue("ActFixConversionGoalSettingOppr")
+    ACT_FIX_CONVERSION_GOAL_SETTING_OPPR("ActFixConversionGoalSettingOppr"),
+    @XmlEnumValue("ActFixConversionTrackingOppr")
+    ACT_FIX_CONVERSION_TRACKING_OPPR("ActFixConversionTrackingOppr"),
+    @XmlEnumValue("ActGeneralBudgetOppr")
+    ACT_GENERAL_BUDGET_OPPR("ActGeneralBudgetOppr"),
+    @XmlEnumValue("ActNewConversionGoalOppr")
+    ACT_NEW_CONVERSION_GOAL_OPPR("ActNewConversionGoalOppr"),
+    @XmlEnumValue("ActInvoiceAccountPaused")
+    ACT_INVOICE_ACCOUNT_PAUSED("ActInvoiceAccountPaused"),
+    @XmlEnumValue("ActInvoiceAccountOnHold")
+    ACT_INVOICE_ACCOUNT_ON_HOLD("ActInvoiceAccountOnHold"),
+    @XmlEnumValue("ActPrepayAccountPaused")
+    ACT_PREPAY_ACCOUNT_PAUSED("ActPrepayAccountPaused"),
+    @XmlEnumValue("ActReallocateBudgetOppr")
+    ACT_REALLOCATE_BUDGET_OPPR("ActReallocateBudgetOppr"),
+    @XmlEnumValue("ActRepairKeywordsOppr")
+    ACT_REPAIR_KEYWORDS_OPPR("ActRepairKeywordsOppr"),
+    @XmlEnumValue("ActRSAOppr")
+    ACT_RSA_OPPR("ActRSAOppr"),
+    @XmlEnumValue("ActSearchTerm")
+    ACT_SEARCH_TERM("ActSearchTerm"),
+    @XmlEnumValue("ActSetupConversionTrackingOppr")
+    ACT_SETUP_CONVERSION_TRACKING_OPPR("ActSetupConversionTrackingOppr"),
+    @XmlEnumValue("ActSiteLinkOppr")
+    ACT_SITE_LINK_OPPR("ActSiteLinkOppr"),
+    @XmlEnumValue("ActThresholdAccountOnHold")
+    ACT_THRESHOLD_ACCOUNT_ON_HOLD("ActThresholdAccountOnHold"),
+    @XmlEnumValue("ActWebsiteExclusion")
+    ACT_WEBSITE_EXCLUSION("ActWebsiteExclusion");
+    private final String value;
+
+    PerformanceInsightsMessageTemplateId(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    public static PerformanceInsightsMessageTemplateId fromValue(String v) {
+        for (PerformanceInsightsMessageTemplateId c: PerformanceInsightsMessageTemplateId.values()) {
+            if (c.value.equals(v)) {
+                return c;
+            }
+        }
+        throw new IllegalArgumentException(v);
+    }
+
+}

--- a/proxies/com/microsoft/bingads/v13/adinsight/PerformanceInsightsUrlCategory.java
+++ b/proxies/com/microsoft/bingads/v13/adinsight/PerformanceInsightsUrlCategory.java
@@ -1,0 +1,57 @@
+
+package com.microsoft.bingads.v13.adinsight;
+
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java class for PerformanceInsightsUrlCategory.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>
+ * <pre>
+ * &lt;simpleType name="PerformanceInsightsUrlCategory">
+ *   &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string">
+ *     &lt;enumeration value="Recommendation"/>
+ *     &lt;enumeration value="Setting"/>
+ *     &lt;enumeration value="Report"/>
+ *     &lt;enumeration value="HelpDoc"/>
+ *   &lt;/restriction>
+ * &lt;/simpleType>
+ * </pre>
+ * 
+ */
+@XmlType(name = "PerformanceInsightsUrlCategory")
+@XmlEnum
+public enum PerformanceInsightsUrlCategory {
+
+    @XmlEnumValue("Recommendation")
+    RECOMMENDATION("Recommendation"),
+    @XmlEnumValue("Setting")
+    SETTING("Setting"),
+    @XmlEnumValue("Report")
+    REPORT("Report"),
+    @XmlEnumValue("HelpDoc")
+    HELP_DOC("HelpDoc");
+    private final String value;
+
+    PerformanceInsightsUrlCategory(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    public static PerformanceInsightsUrlCategory fromValue(String v) {
+        for (PerformanceInsightsUrlCategory c: PerformanceInsightsUrlCategory.values()) {
+            if (c.value.equals(v)) {
+                return c;
+            }
+        }
+        throw new IllegalArgumentException(v);
+    }
+
+}

--- a/proxies/com/microsoft/bingads/v13/adinsight/PerformanceInsightsUrlId.java
+++ b/proxies/com/microsoft/bingads/v13/adinsight/PerformanceInsightsUrlId.java
@@ -1,0 +1,96 @@
+
+package com.microsoft.bingads.v13.adinsight;
+
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java class for PerformanceInsightsUrlId.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>
+ * <pre>
+ * &lt;simpleType name="PerformanceInsightsUrlId">
+ *   &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string">
+ *     &lt;enumeration value="RecRecommendationPage"/>
+ *     &lt;enumeration value="RecCompetitionPage"/>
+ *     &lt;enumeration value="SettingCreateOrder"/>
+ *     &lt;enumeration value="SettingRemoveHold"/>
+ *     &lt;enumeration value="SettingAddFunds"/>
+ *     &lt;enumeration value="ReportSearchTerm"/>
+ *     &lt;enumeration value="ReportPublisherWebsite"/>
+ *     &lt;enumeration value="ReportAuctionInsights"/>
+ *     &lt;enumeration value="HelpDocNetworkSetting"/>
+ *     &lt;enumeration value="HelpDocEditorial"/>
+ *     &lt;enumeration value="HelpDocWebsiteReport"/>
+ *     &lt;enumeration value="HelpDocWebsiteExclusion"/>
+ *     &lt;enumeration value="HelpDocCreateOrder"/>
+ *     &lt;enumeration value="HelpDocRemoveHold"/>
+ *     &lt;enumeration value="HelpDocAddFunds"/>
+ *     &lt;enumeration value="HelpDocRecommendation"/>
+ *     &lt;enumeration value="HelpDocAudienceNetwork"/>
+ *   &lt;/restriction>
+ * &lt;/simpleType>
+ * </pre>
+ * 
+ */
+@XmlType(name = "PerformanceInsightsUrlId")
+@XmlEnum
+public enum PerformanceInsightsUrlId {
+
+    @XmlEnumValue("RecRecommendationPage")
+    REC_RECOMMENDATION_PAGE("RecRecommendationPage"),
+    @XmlEnumValue("RecCompetitionPage")
+    REC_COMPETITION_PAGE("RecCompetitionPage"),
+    @XmlEnumValue("SettingCreateOrder")
+    SETTING_CREATE_ORDER("SettingCreateOrder"),
+    @XmlEnumValue("SettingRemoveHold")
+    SETTING_REMOVE_HOLD("SettingRemoveHold"),
+    @XmlEnumValue("SettingAddFunds")
+    SETTING_ADD_FUNDS("SettingAddFunds"),
+    @XmlEnumValue("ReportSearchTerm")
+    REPORT_SEARCH_TERM("ReportSearchTerm"),
+    @XmlEnumValue("ReportPublisherWebsite")
+    REPORT_PUBLISHER_WEBSITE("ReportPublisherWebsite"),
+    @XmlEnumValue("ReportAuctionInsights")
+    REPORT_AUCTION_INSIGHTS("ReportAuctionInsights"),
+    @XmlEnumValue("HelpDocNetworkSetting")
+    HELP_DOC_NETWORK_SETTING("HelpDocNetworkSetting"),
+    @XmlEnumValue("HelpDocEditorial")
+    HELP_DOC_EDITORIAL("HelpDocEditorial"),
+    @XmlEnumValue("HelpDocWebsiteReport")
+    HELP_DOC_WEBSITE_REPORT("HelpDocWebsiteReport"),
+    @XmlEnumValue("HelpDocWebsiteExclusion")
+    HELP_DOC_WEBSITE_EXCLUSION("HelpDocWebsiteExclusion"),
+    @XmlEnumValue("HelpDocCreateOrder")
+    HELP_DOC_CREATE_ORDER("HelpDocCreateOrder"),
+    @XmlEnumValue("HelpDocRemoveHold")
+    HELP_DOC_REMOVE_HOLD("HelpDocRemoveHold"),
+    @XmlEnumValue("HelpDocAddFunds")
+    HELP_DOC_ADD_FUNDS("HelpDocAddFunds"),
+    @XmlEnumValue("HelpDocRecommendation")
+    HELP_DOC_RECOMMENDATION("HelpDocRecommendation"),
+    @XmlEnumValue("HelpDocAudienceNetwork")
+    HELP_DOC_AUDIENCE_NETWORK("HelpDocAudienceNetwork");
+    private final String value;
+
+    PerformanceInsightsUrlId(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    public static PerformanceInsightsUrlId fromValue(String v) {
+        for (PerformanceInsightsUrlId c: PerformanceInsightsUrlId.values()) {
+            if (c.value.equals(v)) {
+                return c;
+            }
+        }
+        throw new IllegalArgumentException(v);
+    }
+
+}

--- a/proxies/com/microsoft/bingads/v13/adinsight/SetAutoApplyOptInStatusRequest.java
+++ b/proxies/com/microsoft/bingads/v13/adinsight/SetAutoApplyOptInStatusRequest.java
@@ -1,0 +1,64 @@
+
+package com.microsoft.bingads.v13.adinsight;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java class for anonymous complex type.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ * 
+ * <pre>
+ * &lt;complexType>
+ *   &lt;complexContent>
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       &lt;sequence>
+ *         &lt;element name="AutoApplyOptInStatusInputs" type="{http://schemas.microsoft.com/2003/10/Serialization/Arrays}ArrayOfstring" minOccurs="0"/>
+ *       &lt;/sequence>
+ *     &lt;/restriction>
+ *   &lt;/complexContent>
+ * &lt;/complexType>
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "autoApplyOptInStatusInputs"
+})
+@XmlRootElement(name = "SetAutoApplyOptInStatusRequest")
+public class SetAutoApplyOptInStatusRequest {
+
+    @XmlElement(name = "AutoApplyOptInStatusInputs", nillable = true)
+    protected ArrayOfstring autoApplyOptInStatusInputs;
+
+    /**
+     * Gets the value of the autoApplyOptInStatusInputs property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link ArrayOfstring }
+     *     
+     */
+    public ArrayOfstring getAutoApplyOptInStatusInputs() {
+        return autoApplyOptInStatusInputs;
+    }
+
+    /**
+     * Sets the value of the autoApplyOptInStatusInputs property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link ArrayOfstring }
+     *     
+     */
+    public void setAutoApplyOptInStatusInputs(ArrayOfstring value) {
+        this.autoApplyOptInStatusInputs = value;
+    }
+
+}

--- a/proxies/com/microsoft/bingads/v13/adinsight/SetAutoApplyOptInStatusResponse.java
+++ b/proxies/com/microsoft/bingads/v13/adinsight/SetAutoApplyOptInStatusResponse.java
@@ -1,0 +1,64 @@
+
+package com.microsoft.bingads.v13.adinsight;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java class for anonymous complex type.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ * 
+ * <pre>
+ * &lt;complexType>
+ *   &lt;complexContent>
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       &lt;sequence>
+ *         &lt;element name="PartialErrors" type="{https://bingads.microsoft.com/AdInsight/v13}ArrayOfBatchError" minOccurs="0"/>
+ *       &lt;/sequence>
+ *     &lt;/restriction>
+ *   &lt;/complexContent>
+ * &lt;/complexType>
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "partialErrors"
+})
+@XmlRootElement(name = "SetAutoApplyOptInStatusResponse")
+public class SetAutoApplyOptInStatusResponse {
+
+    @XmlElement(name = "PartialErrors", nillable = true)
+    protected ArrayOfBatchError partialErrors;
+
+    /**
+     * Gets the value of the partialErrors property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link ArrayOfBatchError }
+     *     
+     */
+    public ArrayOfBatchError getPartialErrors() {
+        return partialErrors;
+    }
+
+    /**
+     * Sets the value of the partialErrors property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link ArrayOfBatchError }
+     *     
+     */
+    public void setPartialErrors(ArrayOfBatchError value) {
+        this.partialErrors = value;
+    }
+
+}

--- a/proxies/com/microsoft/bingads/v13/adinsight/TextParameter.java
+++ b/proxies/com/microsoft/bingads/v13/adinsight/TextParameter.java
@@ -1,0 +1,64 @@
+
+package com.microsoft.bingads.v13.adinsight;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java class for TextParameter complex type.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ * 
+ * <pre>
+ * &lt;complexType name="TextParameter">
+ *   &lt;complexContent>
+ *     &lt;extension base="{https://bingads.microsoft.com/AdInsight/v13}PerformanceInsightsMessageParameter">
+ *       &lt;sequence>
+ *         &lt;element name="SuggestedText" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/>
+ *       &lt;/sequence>
+ *     &lt;/extension>
+ *   &lt;/complexContent>
+ * &lt;/complexType>
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "TextParameter", propOrder = {
+    "suggestedText"
+})
+public class TextParameter
+    extends PerformanceInsightsMessageParameter
+{
+
+    @XmlElement(name = "SuggestedText", nillable = true)
+    protected String suggestedText;
+
+    /**
+     * Gets the value of the suggestedText property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getSuggestedText() {
+        return suggestedText;
+    }
+
+    /**
+     * Sets the value of the suggestedText property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setSuggestedText(String value) {
+        this.suggestedText = value;
+    }
+
+}

--- a/proxies/com/microsoft/bingads/v13/adinsight/UrlParameter.java
+++ b/proxies/com/microsoft/bingads/v13/adinsight/UrlParameter.java
@@ -1,0 +1,151 @@
+
+package com.microsoft.bingads.v13.adinsight;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlSchemaType;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java class for UrlParameter complex type.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ * 
+ * <pre>
+ * &lt;complexType name="UrlParameter">
+ *   &lt;complexContent>
+ *     &lt;extension base="{https://bingads.microsoft.com/AdInsight/v13}PerformanceInsightsMessageParameter">
+ *       &lt;sequence>
+ *         &lt;element name="SuggestedText" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/>
+ *         &lt;element name="SuggestedUrl" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/>
+ *         &lt;element name="UrlCategory" type="{https://bingads.microsoft.com/AdInsight/v13}PerformanceInsightsUrlCategory" minOccurs="0"/>
+ *         &lt;element name="UrlId" type="{https://bingads.microsoft.com/AdInsight/v13}PerformanceInsightsUrlId" minOccurs="0"/>
+ *       &lt;/sequence>
+ *     &lt;/extension>
+ *   &lt;/complexContent>
+ * &lt;/complexType>
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "UrlParameter", propOrder = {
+    "suggestedText",
+    "suggestedUrl",
+    "urlCategory",
+    "urlId"
+})
+public class UrlParameter
+    extends PerformanceInsightsMessageParameter
+{
+
+    @XmlElement(name = "SuggestedText", nillable = true)
+    protected String suggestedText;
+    @XmlElement(name = "SuggestedUrl", nillable = true)
+    protected String suggestedUrl;
+    @XmlElement(name = "UrlCategory")
+    @XmlSchemaType(name = "string")
+    protected PerformanceInsightsUrlCategory urlCategory;
+    @XmlElement(name = "UrlId")
+    @XmlSchemaType(name = "string")
+    protected PerformanceInsightsUrlId urlId;
+
+    /**
+     * Gets the value of the suggestedText property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getSuggestedText() {
+        return suggestedText;
+    }
+
+    /**
+     * Sets the value of the suggestedText property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setSuggestedText(String value) {
+        this.suggestedText = value;
+    }
+
+    /**
+     * Gets the value of the suggestedUrl property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getSuggestedUrl() {
+        return suggestedUrl;
+    }
+
+    /**
+     * Sets the value of the suggestedUrl property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setSuggestedUrl(String value) {
+        this.suggestedUrl = value;
+    }
+
+    /**
+     * Gets the value of the urlCategory property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link PerformanceInsightsUrlCategory }
+     *     
+     */
+    public PerformanceInsightsUrlCategory getUrlCategory() {
+        return urlCategory;
+    }
+
+    /**
+     * Sets the value of the urlCategory property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link PerformanceInsightsUrlCategory }
+     *     
+     */
+    public void setUrlCategory(PerformanceInsightsUrlCategory value) {
+        this.urlCategory = value;
+    }
+
+    /**
+     * Gets the value of the urlId property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link PerformanceInsightsUrlId }
+     *     
+     */
+    public PerformanceInsightsUrlId getUrlId() {
+        return urlId;
+    }
+
+    /**
+     * Sets the value of the urlId property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link PerformanceInsightsUrlId }
+     *     
+     */
+    public void setUrlId(PerformanceInsightsUrlId value) {
+        this.urlId = value;
+    }
+
+}

--- a/proxies/com/microsoft/bingads/v13/bulk/DownloadEntity.java
+++ b/proxies/com/microsoft/bingads/v13/bulk/DownloadEntity.java
@@ -153,6 +153,11 @@ import javax.xml.bind.annotation.XmlType;
  *     &lt;enumeration value="Videos"/>
  *     &lt;enumeration value="DisclaimerAdExtensions"/>
  *     &lt;enumeration value="CampaignDisclaimerAdExtensions"/>
+ *     &lt;enumeration value="AdcustomizerAttribute"/>
+ *     &lt;enumeration value="CampaignAdcustomizerAttribute"/>
+ *     &lt;enumeration value="AdGroupAdcustomizerAttribute"/>
+ *     &lt;enumeration value="KeywordAdcustomizerAttribute"/>
+ *     &lt;enumeration value="CampaignConversionGoal"/>
  *   &lt;/restriction>
  * &lt;/simpleType>
  * </pre>
@@ -439,7 +444,17 @@ public enum DownloadEntity {
     @XmlEnumValue("DisclaimerAdExtensions")
     DISCLAIMER_AD_EXTENSIONS("DisclaimerAdExtensions"),
     @XmlEnumValue("CampaignDisclaimerAdExtensions")
-    CAMPAIGN_DISCLAIMER_AD_EXTENSIONS("CampaignDisclaimerAdExtensions");
+    CAMPAIGN_DISCLAIMER_AD_EXTENSIONS("CampaignDisclaimerAdExtensions"),
+    @XmlEnumValue("AdcustomizerAttribute")
+    ADCUSTOMIZER_ATTRIBUTE("AdcustomizerAttribute"),
+    @XmlEnumValue("CampaignAdcustomizerAttribute")
+    CAMPAIGN_ADCUSTOMIZER_ATTRIBUTE("CampaignAdcustomizerAttribute"),
+    @XmlEnumValue("AdGroupAdcustomizerAttribute")
+    AD_GROUP_ADCUSTOMIZER_ATTRIBUTE("AdGroupAdcustomizerAttribute"),
+    @XmlEnumValue("KeywordAdcustomizerAttribute")
+    KEYWORD_ADCUSTOMIZER_ATTRIBUTE("KeywordAdcustomizerAttribute"),
+    @XmlEnumValue("CampaignConversionGoal")
+    CAMPAIGN_CONVERSION_GOAL("CampaignConversionGoal");
     private final String value;
 
     DownloadEntity(String v) {

--- a/proxies/com/microsoft/bingads/v13/bulk/IBulkService.java
+++ b/proxies/com/microsoft/bingads/v13/bulk/IBulkService.java
@@ -56,8 +56,8 @@ public interface IBulkService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.bulk.DownloadCampaignsByAccountIdsResponse
-     * @throws ApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFaultDetail_Exception
      */
     @WebMethod(operationName = "DownloadCampaignsByAccountIds", action = "DownloadCampaignsByAccountIds")
     @WebResult(name = "DownloadCampaignsByAccountIdsResponse", targetNamespace = "https://bingads.microsoft.com/CampaignManagement/v13", partName = "parameters")
@@ -97,8 +97,8 @@ public interface IBulkService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.bulk.DownloadCampaignsByCampaignIdsResponse
-     * @throws ApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFaultDetail_Exception
      */
     @WebMethod(operationName = "DownloadCampaignsByCampaignIds", action = "DownloadCampaignsByCampaignIds")
     @WebResult(name = "DownloadCampaignsByCampaignIdsResponse", targetNamespace = "https://bingads.microsoft.com/CampaignManagement/v13", partName = "parameters")
@@ -138,8 +138,8 @@ public interface IBulkService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.bulk.GetBulkDownloadStatusResponse
-     * @throws ApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetBulkDownloadStatus", action = "GetBulkDownloadStatus")
     @WebResult(name = "GetBulkDownloadStatusResponse", targetNamespace = "https://bingads.microsoft.com/CampaignManagement/v13", partName = "parameters")
@@ -179,8 +179,8 @@ public interface IBulkService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.bulk.GetBulkUploadUrlResponse
-     * @throws ApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetBulkUploadUrl", action = "GetBulkUploadUrl")
     @WebResult(name = "GetBulkUploadUrlResponse", targetNamespace = "https://bingads.microsoft.com/CampaignManagement/v13", partName = "parameters")
@@ -220,8 +220,8 @@ public interface IBulkService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.bulk.GetBulkUploadStatusResponse
-     * @throws ApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetBulkUploadStatus", action = "GetBulkUploadStatus")
     @WebResult(name = "GetBulkUploadStatusResponse", targetNamespace = "https://bingads.microsoft.com/CampaignManagement/v13", partName = "parameters")
@@ -261,8 +261,8 @@ public interface IBulkService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.bulk.UploadEntityRecordsResponse
-     * @throws ApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFaultDetail_Exception
      */
     @WebMethod(operationName = "UploadEntityRecords", action = "UploadEntityRecords")
     @WebResult(name = "UploadEntityRecordsResponse", targetNamespace = "https://bingads.microsoft.com/CampaignManagement/v13", partName = "parameters")

--- a/proxies/com/microsoft/bingads/v13/campaignmanagement/AccountPropertyName.java
+++ b/proxies/com/microsoft/bingads/v13/campaignmanagement/AccountPropertyName.java
@@ -27,6 +27,7 @@ import javax.xml.bind.annotation.XmlType;
  *     &lt;enumeration value="AutoBiddingViewThroughConversionsValueAttributionWeight"/>
  *     &lt;enumeration value="LoopBackWindowForViewThroughConversions"/>
  *     &lt;enumeration value="BusinessAttributes"/>
+ *     &lt;enumeration value="EnableMMAUnderDSAAdgroups"/>
  *   &lt;/restriction>
  * &lt;/simpleType>
  * </pre>
@@ -61,7 +62,9 @@ public enum AccountPropertyName {
     @XmlEnumValue("LoopBackWindowForViewThroughConversions")
     LOOP_BACK_WINDOW_FOR_VIEW_THROUGH_CONVERSIONS("LoopBackWindowForViewThroughConversions"),
     @XmlEnumValue("BusinessAttributes")
-    BUSINESS_ATTRIBUTES("BusinessAttributes");
+    BUSINESS_ATTRIBUTES("BusinessAttributes"),
+    @XmlEnumValue("EnableMMAUnderDSAAdgroups")
+    ENABLE_MMA_UNDER_DSA_ADGROUPS("EnableMMAUnderDSAAdgroups");
     private final String value;
 
     AccountPropertyName(String v) {

--- a/proxies/com/microsoft/bingads/v13/campaignmanagement/AddCampaignConversionGoalsRequest.java
+++ b/proxies/com/microsoft/bingads/v13/campaignmanagement/AddCampaignConversionGoalsRequest.java
@@ -1,0 +1,64 @@
+
+package com.microsoft.bingads.v13.campaignmanagement;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java class for anonymous complex type.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ * 
+ * <pre>
+ * &lt;complexType>
+ *   &lt;complexContent>
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       &lt;sequence>
+ *         &lt;element name="CampaignConversionGoal" type="{https://bingads.microsoft.com/CampaignManagement/v13}ArrayOfCampaignConversionGoal" minOccurs="0"/>
+ *       &lt;/sequence>
+ *     &lt;/restriction>
+ *   &lt;/complexContent>
+ * &lt;/complexType>
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "campaignConversionGoal"
+})
+@XmlRootElement(name = "AddCampaignConversionGoalsRequest")
+public class AddCampaignConversionGoalsRequest {
+
+    @XmlElement(name = "CampaignConversionGoal", nillable = true)
+    protected ArrayOfCampaignConversionGoal campaignConversionGoal;
+
+    /**
+     * Gets the value of the campaignConversionGoal property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link ArrayOfCampaignConversionGoal }
+     *     
+     */
+    public ArrayOfCampaignConversionGoal getCampaignConversionGoal() {
+        return campaignConversionGoal;
+    }
+
+    /**
+     * Sets the value of the campaignConversionGoal property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link ArrayOfCampaignConversionGoal }
+     *     
+     */
+    public void setCampaignConversionGoal(ArrayOfCampaignConversionGoal value) {
+        this.campaignConversionGoal = value;
+    }
+
+}

--- a/proxies/com/microsoft/bingads/v13/campaignmanagement/AddCampaignConversionGoalsResponse.java
+++ b/proxies/com/microsoft/bingads/v13/campaignmanagement/AddCampaignConversionGoalsResponse.java
@@ -1,0 +1,64 @@
+
+package com.microsoft.bingads.v13.campaignmanagement;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java class for anonymous complex type.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ * 
+ * <pre>
+ * &lt;complexType>
+ *   &lt;complexContent>
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       &lt;sequence>
+ *         &lt;element name="PartialErrors" type="{https://bingads.microsoft.com/CampaignManagement/v13}ArrayOfBatchError" minOccurs="0"/>
+ *       &lt;/sequence>
+ *     &lt;/restriction>
+ *   &lt;/complexContent>
+ * &lt;/complexType>
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "partialErrors"
+})
+@XmlRootElement(name = "AddCampaignConversionGoalsResponse")
+public class AddCampaignConversionGoalsResponse {
+
+    @XmlElement(name = "PartialErrors", nillable = true)
+    protected ArrayOfBatchError partialErrors;
+
+    /**
+     * Gets the value of the partialErrors property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link ArrayOfBatchError }
+     *     
+     */
+    public ArrayOfBatchError getPartialErrors() {
+        return partialErrors;
+    }
+
+    /**
+     * Sets the value of the partialErrors property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link ArrayOfBatchError }
+     *     
+     */
+    public void setPartialErrors(ArrayOfBatchError value) {
+        this.partialErrors = value;
+    }
+
+}

--- a/proxies/com/microsoft/bingads/v13/campaignmanagement/ArrayOfCampaignConversionGoal.java
+++ b/proxies/com/microsoft/bingads/v13/campaignmanagement/ArrayOfCampaignConversionGoal.java
@@ -1,0 +1,69 @@
+
+package com.microsoft.bingads.v13.campaignmanagement;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java class for ArrayOfCampaignConversionGoal complex type.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ * 
+ * <pre>
+ * &lt;complexType name="ArrayOfCampaignConversionGoal">
+ *   &lt;complexContent>
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       &lt;sequence>
+ *         &lt;element name="CampaignConversionGoal" type="{https://bingads.microsoft.com/CampaignManagement/v13}CampaignConversionGoal" maxOccurs="unbounded" minOccurs="0"/>
+ *       &lt;/sequence>
+ *     &lt;/restriction>
+ *   &lt;/complexContent>
+ * &lt;/complexType>
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "ArrayOfCampaignConversionGoal", propOrder = {
+    "campaignConversionGoals"
+})
+public class ArrayOfCampaignConversionGoal {
+
+    @XmlElement(name = "CampaignConversionGoal", nillable = true)
+    protected List<CampaignConversionGoal> campaignConversionGoals;
+
+    /**
+     * Gets the value of the campaignConversionGoals property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the campaignConversionGoals property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getCampaignConversionGoals().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link CampaignConversionGoal }
+     * 
+     * 
+     */
+    public List<CampaignConversionGoal> getCampaignConversionGoals() {
+        if (campaignConversionGoals == null) {
+            campaignConversionGoals = new ArrayList<CampaignConversionGoal>();
+        }
+        return this.campaignConversionGoals;
+    }
+
+}

--- a/proxies/com/microsoft/bingads/v13/campaignmanagement/AttributionModelType.java
+++ b/proxies/com/microsoft/bingads/v13/campaignmanagement/AttributionModelType.java
@@ -1,0 +1,51 @@
+
+package com.microsoft.bingads.v13.campaignmanagement;
+
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java class for AttributionModelType.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>
+ * <pre>
+ * &lt;simpleType name="AttributionModelType">
+ *   &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string">
+ *     &lt;enumeration value="LastClick"/>
+ *     &lt;enumeration value="LastTouch"/>
+ *   &lt;/restriction>
+ * &lt;/simpleType>
+ * </pre>
+ * 
+ */
+@XmlType(name = "AttributionModelType")
+@XmlEnum
+public enum AttributionModelType {
+
+    @XmlEnumValue("LastClick")
+    LAST_CLICK("LastClick"),
+    @XmlEnumValue("LastTouch")
+    LAST_TOUCH("LastTouch");
+    private final String value;
+
+    AttributionModelType(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    public static AttributionModelType fromValue(String v) {
+        for (AttributionModelType c: AttributionModelType.values()) {
+            if (c.value.equals(v)) {
+                return c;
+            }
+        }
+        throw new IllegalArgumentException(v);
+    }
+
+}

--- a/proxies/com/microsoft/bingads/v13/campaignmanagement/CallToAction.java
+++ b/proxies/com/microsoft/bingads/v13/campaignmanagement/CallToAction.java
@@ -94,6 +94,15 @@ import javax.xml.bind.annotation.XmlType;
  *     &lt;enumeration value="Buy"/>
  *     &lt;enumeration value="OpenLink"/>
  *     &lt;enumeration value="RegisterNow"/>
+ *     &lt;enumeration value="BuildNow"/>
+ *     &lt;enumeration value="Dealers"/>
+ *     &lt;enumeration value="GetDemo"/>
+ *     &lt;enumeration value="GetNow"/>
+ *     &lt;enumeration value="GoToDemo"/>
+ *     &lt;enumeration value="SeeDemo"/>
+ *     &lt;enumeration value="SeeModels"/>
+ *     &lt;enumeration value="SeeOffers"/>
+ *     &lt;enumeration value="ViewDemo"/>
  *     &lt;enumeration value="Automated"/>
  *   &lt;/restriction>
  * &lt;/simpleType>
@@ -264,6 +273,24 @@ public enum CallToAction {
     OPEN_LINK("OpenLink"),
     @XmlEnumValue("RegisterNow")
     REGISTER_NOW("RegisterNow"),
+    @XmlEnumValue("BuildNow")
+    BUILD_NOW("BuildNow"),
+    @XmlEnumValue("Dealers")
+    DEALERS("Dealers"),
+    @XmlEnumValue("GetDemo")
+    GET_DEMO("GetDemo"),
+    @XmlEnumValue("GetNow")
+    GET_NOW("GetNow"),
+    @XmlEnumValue("GoToDemo")
+    GO_TO_DEMO("GoToDemo"),
+    @XmlEnumValue("SeeDemo")
+    SEE_DEMO("SeeDemo"),
+    @XmlEnumValue("SeeModels")
+    SEE_MODELS("SeeModels"),
+    @XmlEnumValue("SeeOffers")
+    SEE_OFFERS("SeeOffers"),
+    @XmlEnumValue("ViewDemo")
+    VIEW_DEMO("ViewDemo"),
     @XmlEnumValue("Automated")
     AUTOMATED("Automated");
     private final String value;

--- a/proxies/com/microsoft/bingads/v13/campaignmanagement/Campaign.java
+++ b/proxies/com/microsoft/bingads/v13/campaignmanagement/Campaign.java
@@ -27,6 +27,7 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
  *         &lt;element name="ExperimentId" type="{http://www.w3.org/2001/XMLSchema}long" minOccurs="0"/>
  *         &lt;element name="FinalUrlSuffix" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/>
  *         &lt;element name="ForwardCompatibilityMap" type="{http://schemas.datacontract.org/2004/07/System.Collections.Generic}ArrayOfKeyValuePairOfstringstring" minOccurs="0"/>
+ *         &lt;element name="GoalIds" type="{http://schemas.microsoft.com/2003/10/Serialization/Arrays}ArrayOflong" minOccurs="0"/>
  *         &lt;element name="Id" type="{http://www.w3.org/2001/XMLSchema}long" minOccurs="0"/>
  *         &lt;element name="MultimediaAdsBidAdjustment" type="{http://www.w3.org/2001/XMLSchema}int" minOccurs="0"/>
  *         &lt;element name="Name" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/>
@@ -58,6 +59,7 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
     "experimentId",
     "finalUrlSuffix",
     "forwardCompatibilityMap",
+    "goalIds",
     "id",
     "multimediaAdsBidAdjustment",
     "name",
@@ -90,6 +92,8 @@ public class Campaign {
     protected String finalUrlSuffix;
     @XmlElement(name = "ForwardCompatibilityMap", nillable = true)
     protected ArrayOfKeyValuePairOfstringstring forwardCompatibilityMap;
+    @XmlElement(name = "GoalIds", nillable = true)
+    protected ArrayOflong goalIds;
     @XmlElement(name = "Id", nillable = true)
     protected Long id;
     @XmlElement(name = "MultimediaAdsBidAdjustment", nillable = true)
@@ -287,6 +291,30 @@ public class Campaign {
      */
     public void setForwardCompatibilityMap(ArrayOfKeyValuePairOfstringstring value) {
         this.forwardCompatibilityMap = value;
+    }
+
+    /**
+     * Gets the value of the goalIds property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link ArrayOflong }
+     *     
+     */
+    public ArrayOflong getGoalIds() {
+        return goalIds;
+    }
+
+    /**
+     * Sets the value of the goalIds property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link ArrayOflong }
+     *     
+     */
+    public void setGoalIds(ArrayOflong value) {
+        this.goalIds = value;
     }
 
     /**

--- a/proxies/com/microsoft/bingads/v13/campaignmanagement/CampaignAdditionalField.java
+++ b/proxies/com/microsoft/bingads/v13/campaignmanagement/CampaignAdditionalField.java
@@ -15,7 +15,8 @@ public enum CampaignAdditionalField {
     MULTIMEDIA_ADS_BID_ADJUSTMENT("MultimediaAdsBidAdjustment"),
     VERIFIED_TRACKING_SETTING("VerifiedTrackingSetting"),
     DYNAMIC_DESCRIPTION_SETTING("DynamicDescriptionSetting"),
-    DISCLAIMER_SETTING("DisclaimerSetting");
+    DISCLAIMER_SETTING("DisclaimerSetting"),
+    CAMPAIGN_CONVERSION_GOAL("CampaignConversionGoal");
         
     private final String value;
 

--- a/proxies/com/microsoft/bingads/v13/campaignmanagement/CampaignConversionGoal.java
+++ b/proxies/com/microsoft/bingads/v13/campaignmanagement/CampaignConversionGoal.java
@@ -1,0 +1,74 @@
+
+package com.microsoft.bingads.v13.campaignmanagement;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java class for CampaignConversionGoal complex type.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ * 
+ * <pre>
+ * &lt;complexType name="CampaignConversionGoal">
+ *   &lt;complexContent>
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       &lt;sequence>
+ *         &lt;element name="CampaignId" type="{http://www.w3.org/2001/XMLSchema}long"/>
+ *         &lt;element name="GoalId" type="{http://www.w3.org/2001/XMLSchema}long"/>
+ *       &lt;/sequence>
+ *     &lt;/restriction>
+ *   &lt;/complexContent>
+ * &lt;/complexType>
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "CampaignConversionGoal", propOrder = {
+    "campaignId",
+    "goalId"
+})
+public class CampaignConversionGoal {
+
+    @XmlElement(name = "CampaignId")
+    protected long campaignId;
+    @XmlElement(name = "GoalId")
+    protected long goalId;
+
+    /**
+     * Gets the value of the campaignId property.
+     * 
+     */
+    public long getCampaignId() {
+        return campaignId;
+    }
+
+    /**
+     * Sets the value of the campaignId property.
+     * 
+     */
+    public void setCampaignId(long value) {
+        this.campaignId = value;
+    }
+
+    /**
+     * Gets the value of the goalId property.
+     * 
+     */
+    public long getGoalId() {
+        return goalId;
+    }
+
+    /**
+     * Sets the value of the goalId property.
+     * 
+     */
+    public void setGoalId(long value) {
+        this.goalId = value;
+    }
+
+}

--- a/proxies/com/microsoft/bingads/v13/campaignmanagement/ConversionGoal.java
+++ b/proxies/com/microsoft/bingads/v13/campaignmanagement/ConversionGoal.java
@@ -21,6 +21,7 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
  *   &lt;complexContent>
  *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
  *       &lt;sequence>
+ *         &lt;element name="AttributionModelType" type="{https://bingads.microsoft.com/CampaignManagement/v13}AttributionModelType" minOccurs="0"/>
  *         &lt;element name="ConversionWindowInMinutes" type="{http://www.w3.org/2001/XMLSchema}int" minOccurs="0"/>
  *         &lt;element name="CountType" type="{https://bingads.microsoft.com/CampaignManagement/v13}ConversionGoalCountType" minOccurs="0"/>
  *         &lt;element name="ExcludeFromBidding" type="{http://www.w3.org/2001/XMLSchema}boolean" minOccurs="0"/>
@@ -44,6 +45,7 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "ConversionGoal", propOrder = {
+    "attributionModelType",
     "conversionWindowInMinutes",
     "countType",
     "excludeFromBidding",
@@ -69,6 +71,9 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 })
 public class ConversionGoal {
 
+    @XmlElement(name = "AttributionModelType", nillable = true)
+    @XmlSchemaType(name = "string")
+    protected AttributionModelType attributionModelType;
     @XmlElement(name = "ConversionWindowInMinutes", nillable = true)
     protected Integer conversionWindowInMinutes;
     @XmlElement(name = "CountType", nillable = true)
@@ -101,6 +106,30 @@ public class ConversionGoal {
     protected Collection<ConversionGoalType> type;
     @XmlElement(name = "ViewThroughConversionWindowInMinutes", nillable = true)
     protected Integer viewThroughConversionWindowInMinutes;
+
+    /**
+     * Gets the value of the attributionModelType property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link AttributionModelType }
+     *     
+     */
+    public AttributionModelType getAttributionModelType() {
+        return attributionModelType;
+    }
+
+    /**
+     * Sets the value of the attributionModelType property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link AttributionModelType }
+     *     
+     */
+    public void setAttributionModelType(AttributionModelType value) {
+        this.attributionModelType = value;
+    }
 
     /**
      * Gets the value of the conversionWindowInMinutes property.

--- a/proxies/com/microsoft/bingads/v13/campaignmanagement/ConversionGoalAdditionalField.java
+++ b/proxies/com/microsoft/bingads/v13/campaignmanagement/ConversionGoalAdditionalField.java
@@ -8,7 +8,8 @@ public enum ConversionGoalAdditionalField {
     VIEW_THROUGH_CONVERSION_WINDOW_IN_MINUTES("ViewThroughConversionWindowInMinutes"),
     IS_EXTERNALLY_ATTRIBUTED("IsExternallyAttributed"),
     GOAL_CATEGORY("GoalCategory"),
-    INACTIVE_DUE_TO_TAG_UNAVAILABLE("InactiveDueToTagUnavailable");
+    INACTIVE_DUE_TO_TAG_UNAVAILABLE("InactiveDueToTagUnavailable"),
+    ATTRIBUTION_MODEL_TYPE("AttributionModelType");
         
     private final String value;
 

--- a/proxies/com/microsoft/bingads/v13/campaignmanagement/DeleteCampaignConversionGoalsRequest.java
+++ b/proxies/com/microsoft/bingads/v13/campaignmanagement/DeleteCampaignConversionGoalsRequest.java
@@ -1,0 +1,64 @@
+
+package com.microsoft.bingads.v13.campaignmanagement;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java class for anonymous complex type.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ * 
+ * <pre>
+ * &lt;complexType>
+ *   &lt;complexContent>
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       &lt;sequence>
+ *         &lt;element name="CampaignConversionGoal" type="{https://bingads.microsoft.com/CampaignManagement/v13}ArrayOfCampaignConversionGoal" minOccurs="0"/>
+ *       &lt;/sequence>
+ *     &lt;/restriction>
+ *   &lt;/complexContent>
+ * &lt;/complexType>
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "campaignConversionGoal"
+})
+@XmlRootElement(name = "DeleteCampaignConversionGoalsRequest")
+public class DeleteCampaignConversionGoalsRequest {
+
+    @XmlElement(name = "CampaignConversionGoal", nillable = true)
+    protected ArrayOfCampaignConversionGoal campaignConversionGoal;
+
+    /**
+     * Gets the value of the campaignConversionGoal property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link ArrayOfCampaignConversionGoal }
+     *     
+     */
+    public ArrayOfCampaignConversionGoal getCampaignConversionGoal() {
+        return campaignConversionGoal;
+    }
+
+    /**
+     * Sets the value of the campaignConversionGoal property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link ArrayOfCampaignConversionGoal }
+     *     
+     */
+    public void setCampaignConversionGoal(ArrayOfCampaignConversionGoal value) {
+        this.campaignConversionGoal = value;
+    }
+
+}

--- a/proxies/com/microsoft/bingads/v13/campaignmanagement/DeleteCampaignConversionGoalsResponse.java
+++ b/proxies/com/microsoft/bingads/v13/campaignmanagement/DeleteCampaignConversionGoalsResponse.java
@@ -1,0 +1,64 @@
+
+package com.microsoft.bingads.v13.campaignmanagement;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java class for anonymous complex type.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ * 
+ * <pre>
+ * &lt;complexType>
+ *   &lt;complexContent>
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       &lt;sequence>
+ *         &lt;element name="PartialErrors" type="{https://bingads.microsoft.com/CampaignManagement/v13}ArrayOfBatchError" minOccurs="0"/>
+ *       &lt;/sequence>
+ *     &lt;/restriction>
+ *   &lt;/complexContent>
+ * &lt;/complexType>
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "partialErrors"
+})
+@XmlRootElement(name = "DeleteCampaignConversionGoalsResponse")
+public class DeleteCampaignConversionGoalsResponse {
+
+    @XmlElement(name = "PartialErrors", nillable = true)
+    protected ArrayOfBatchError partialErrors;
+
+    /**
+     * Gets the value of the partialErrors property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link ArrayOfBatchError }
+     *     
+     */
+    public ArrayOfBatchError getPartialErrors() {
+        return partialErrors;
+    }
+
+    /**
+     * Sets the value of the partialErrors property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link ArrayOfBatchError }
+     *     
+     */
+    public void setPartialErrors(ArrayOfBatchError value) {
+        this.partialErrors = value;
+    }
+
+}

--- a/proxies/com/microsoft/bingads/v13/campaignmanagement/GoogleImportOption.java
+++ b/proxies/com/microsoft/bingads/v13/campaignmanagement/GoogleImportOption.java
@@ -67,6 +67,7 @@ import javax.xml.bind.annotation.XmlType;
  *         &lt;element name="SearchAndDsaMixedCampaignAsSearchCampaign" type="{http://www.w3.org/2001/XMLSchema}boolean" minOccurs="0"/>
  *         &lt;element name="SearchAndReplaceForCampaignNames" type="{https://bingads.microsoft.com/CampaignManagement/v13}ImportSearchAndReplaceForStringProperty" minOccurs="0"/>
  *         &lt;element name="SearchAndReplaceForCustomParameters" type="{https://bingads.microsoft.com/CampaignManagement/v13}ImportSearchAndReplaceForStringProperty" minOccurs="0"/>
+ *         &lt;element name="SearchAndReplaceForFinalURLSuffix" type="{https://bingads.microsoft.com/CampaignManagement/v13}ImportSearchAndReplaceForStringProperty" minOccurs="0"/>
  *         &lt;element name="SearchAndReplaceForTrackingTemplates" type="{https://bingads.microsoft.com/CampaignManagement/v13}ImportSearchAndReplaceForStringProperty" minOccurs="0"/>
  *         &lt;element name="SearchAndReplaceForUrls" type="{https://bingads.microsoft.com/CampaignManagement/v13}ImportSearchAndReplaceForStringProperty" minOccurs="0"/>
  *         &lt;element name="SuffixForCampaignNames" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/>
@@ -166,6 +167,7 @@ import javax.xml.bind.annotation.XmlType;
     "searchAndDsaMixedCampaignAsSearchCampaign",
     "searchAndReplaceForCampaignNames",
     "searchAndReplaceForCustomParameters",
+    "searchAndReplaceForFinalURLSuffix",
     "searchAndReplaceForTrackingTemplates",
     "searchAndReplaceForUrls",
     "suffixForCampaignNames",
@@ -310,6 +312,8 @@ public class GoogleImportOption
     protected ImportSearchAndReplaceForStringProperty searchAndReplaceForCampaignNames;
     @XmlElement(name = "SearchAndReplaceForCustomParameters", nillable = true)
     protected ImportSearchAndReplaceForStringProperty searchAndReplaceForCustomParameters;
+    @XmlElement(name = "SearchAndReplaceForFinalURLSuffix", nillable = true)
+    protected ImportSearchAndReplaceForStringProperty searchAndReplaceForFinalURLSuffix;
     @XmlElement(name = "SearchAndReplaceForTrackingTemplates", nillable = true)
     protected ImportSearchAndReplaceForStringProperty searchAndReplaceForTrackingTemplates;
     @XmlElement(name = "SearchAndReplaceForUrls", nillable = true)
@@ -1587,6 +1591,30 @@ public class GoogleImportOption
      */
     public void setSearchAndReplaceForCustomParameters(ImportSearchAndReplaceForStringProperty value) {
         this.searchAndReplaceForCustomParameters = value;
+    }
+
+    /**
+     * Gets the value of the searchAndReplaceForFinalURLSuffix property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link ImportSearchAndReplaceForStringProperty }
+     *     
+     */
+    public ImportSearchAndReplaceForStringProperty getSearchAndReplaceForFinalURLSuffix() {
+        return searchAndReplaceForFinalURLSuffix;
+    }
+
+    /**
+     * Sets the value of the searchAndReplaceForFinalURLSuffix property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link ImportSearchAndReplaceForStringProperty }
+     *     
+     */
+    public void setSearchAndReplaceForFinalURLSuffix(ImportSearchAndReplaceForStringProperty value) {
+        this.searchAndReplaceForFinalURLSuffix = value;
     }
 
     /**

--- a/proxies/com/microsoft/bingads/v13/campaignmanagement/ICampaignManagementService.java
+++ b/proxies/com/microsoft/bingads/v13/campaignmanagement/ICampaignManagementService.java
@@ -5028,4 +5028,86 @@ public interface ICampaignManagementService {
         throws AdApiFaultDetail_Exception, ApiFaultDetail_Exception
     ;
 
+    /**
+     * 
+     * @param parameters
+     * @return
+     *     returns javax.xml.ws.Response<com.microsoft.bingads.v13.campaignmanagement.AddCampaignConversionGoalsResponse>
+     */
+    @WebMethod(operationName = "AddCampaignConversionGoals", action = "AddCampaignConversionGoals")
+    public Response<AddCampaignConversionGoalsResponse> addCampaignConversionGoalsAsync(
+        @WebParam(name = "AddCampaignConversionGoalsRequest", targetNamespace = "https://bingads.microsoft.com/CampaignManagement/v13", partName = "parameters")
+        AddCampaignConversionGoalsRequest parameters);
+
+    /**
+     * 
+     * @param asyncHandler
+     * @param parameters
+     * @return
+     *     returns java.util.concurrent.Future<? extends java.lang.Object>
+     */
+    @WebMethod(operationName = "AddCampaignConversionGoals", action = "AddCampaignConversionGoals")
+    public Future<?> addCampaignConversionGoalsAsync(
+        @WebParam(name = "AddCampaignConversionGoalsRequest", targetNamespace = "https://bingads.microsoft.com/CampaignManagement/v13", partName = "parameters")
+        AddCampaignConversionGoalsRequest parameters,
+        @WebParam(name = "AddCampaignConversionGoalsResponse", targetNamespace = "", partName = "asyncHandler")
+        AsyncHandler<AddCampaignConversionGoalsResponse> asyncHandler);
+
+    /**
+     * 
+     * @param parameters
+     * @return
+     *     returns com.microsoft.bingads.v13.campaignmanagement.AddCampaignConversionGoalsResponse
+     * @throws AdApiFaultDetail_Exception
+     * @throws ApiFaultDetail_Exception
+     */
+    @WebMethod(operationName = "AddCampaignConversionGoals", action = "AddCampaignConversionGoals")
+    @WebResult(name = "AddCampaignConversionGoalsResponse", targetNamespace = "https://bingads.microsoft.com/CampaignManagement/v13", partName = "parameters")
+    public AddCampaignConversionGoalsResponse addCampaignConversionGoals(
+        @WebParam(name = "AddCampaignConversionGoalsRequest", targetNamespace = "https://bingads.microsoft.com/CampaignManagement/v13", partName = "parameters")
+        AddCampaignConversionGoalsRequest parameters)
+        throws AdApiFaultDetail_Exception, ApiFaultDetail_Exception
+    ;
+
+    /**
+     * 
+     * @param parameters
+     * @return
+     *     returns javax.xml.ws.Response<com.microsoft.bingads.v13.campaignmanagement.DeleteCampaignConversionGoalsResponse>
+     */
+    @WebMethod(operationName = "DeleteCampaignConversionGoals", action = "DeleteCampaignConversionGoals")
+    public Response<DeleteCampaignConversionGoalsResponse> deleteCampaignConversionGoalsAsync(
+        @WebParam(name = "DeleteCampaignConversionGoalsRequest", targetNamespace = "https://bingads.microsoft.com/CampaignManagement/v13", partName = "parameters")
+        DeleteCampaignConversionGoalsRequest parameters);
+
+    /**
+     * 
+     * @param asyncHandler
+     * @param parameters
+     * @return
+     *     returns java.util.concurrent.Future<? extends java.lang.Object>
+     */
+    @WebMethod(operationName = "DeleteCampaignConversionGoals", action = "DeleteCampaignConversionGoals")
+    public Future<?> deleteCampaignConversionGoalsAsync(
+        @WebParam(name = "DeleteCampaignConversionGoalsRequest", targetNamespace = "https://bingads.microsoft.com/CampaignManagement/v13", partName = "parameters")
+        DeleteCampaignConversionGoalsRequest parameters,
+        @WebParam(name = "DeleteCampaignConversionGoalsResponse", targetNamespace = "", partName = "asyncHandler")
+        AsyncHandler<DeleteCampaignConversionGoalsResponse> asyncHandler);
+
+    /**
+     * 
+     * @param parameters
+     * @return
+     *     returns com.microsoft.bingads.v13.campaignmanagement.DeleteCampaignConversionGoalsResponse
+     * @throws AdApiFaultDetail_Exception
+     * @throws ApiFaultDetail_Exception
+     */
+    @WebMethod(operationName = "DeleteCampaignConversionGoals", action = "DeleteCampaignConversionGoals")
+    @WebResult(name = "DeleteCampaignConversionGoalsResponse", targetNamespace = "https://bingads.microsoft.com/CampaignManagement/v13", partName = "parameters")
+    public DeleteCampaignConversionGoalsResponse deleteCampaignConversionGoals(
+        @WebParam(name = "DeleteCampaignConversionGoalsRequest", targetNamespace = "https://bingads.microsoft.com/CampaignManagement/v13", partName = "parameters")
+        DeleteCampaignConversionGoalsRequest parameters)
+        throws AdApiFaultDetail_Exception, ApiFaultDetail_Exception
+    ;
+
 }

--- a/proxies/com/microsoft/bingads/v13/campaignmanagement/ImportAdditionalField.java
+++ b/proxies/com/microsoft/bingads/v13/campaignmanagement/ImportAdditionalField.java
@@ -12,7 +12,8 @@ public enum ImportAdditionalField {
     SEARCH_AND_REPLACE_FOR_CUSTOM_PARAMETERS("SearchAndReplaceForCustomParameters"),
     AD_SCHEDULE_USE_SEARCHER_TIMEZONE("AdScheduleUseSearcherTimezone"),
     NEW_IMAGE_AD_EXTENSIONS("NewImageAdExtensions"),
-    UPDATE_IMAGE_AD_EXTENSIONS("UpdateImageAdExtensions");
+    UPDATE_IMAGE_AD_EXTENSIONS("UpdateImageAdExtensions"),
+    SEARCH_AND_REPLACE_FOR_FINAL_U_R_L_SUFFIX("SearchAndReplaceForFinalURLSuffix");
         
     private final String value;
 

--- a/proxies/com/microsoft/bingads/v13/campaignmanagement/LanguageName.java
+++ b/proxies/com/microsoft/bingads/v13/campaignmanagement/LanguageName.java
@@ -49,6 +49,8 @@ import javax.xml.bind.annotation.XmlType;
  *     &lt;enumeration value="Macedonian"/>
  *     &lt;enumeration value="Icelandic"/>
  *     &lt;enumeration value="Japanese"/>
+ *     &lt;enumeration value="Hebrew"/>
+ *     &lt;enumeration value="Russian"/>
  *     &lt;enumeration value="All"/>
  *   &lt;/restriction>
  * &lt;/simpleType>
@@ -129,6 +131,10 @@ public enum LanguageName {
     ICELANDIC("Icelandic"),
     @XmlEnumValue("Japanese")
     JAPANESE("Japanese"),
+    @XmlEnumValue("Hebrew")
+    HEBREW("Hebrew"),
+    @XmlEnumValue("Russian")
+    RUSSIAN("Russian"),
     @XmlEnumValue("All")
     ALL("All");
     private final String value;

--- a/proxies/com/microsoft/bingads/v13/campaignmanagement/ObjectFactory.java
+++ b/proxies/com/microsoft/bingads/v13/campaignmanagement/ObjectFactory.java
@@ -88,6 +88,7 @@ public class ObjectFactory {
     private final static QName _CustomerAccountShareAssociation_QNAME = new QName("https://bingads.microsoft.com/CampaignManagement/v13", "CustomerAccountShareAssociation");
     private final static QName _EntityType_QNAME = new QName("https://bingads.microsoft.com/CampaignManagement/v13", "EntityType");
     private final static QName _BidOption_QNAME = new QName("https://bingads.microsoft.com/CampaignManagement/v13", "BidOption");
+    private final static QName _AttributionModelType_QNAME = new QName("https://bingads.microsoft.com/CampaignManagement/v13", "AttributionModelType");
     private final static QName _MigrationStatusInfo_QNAME = new QName("https://bingads.microsoft.com/CampaignManagement/v13", "MigrationStatusInfo");
     private final static QName _ArrayOfIdCollection_QNAME = new QName("https://bingads.microsoft.com/CampaignManagement/v13", "ArrayOfIdCollection");
     private final static QName _ArrayOfSharedEntity_QNAME = new QName("https://bingads.microsoft.com/CampaignManagement/v13", "ArrayOfSharedEntity");
@@ -203,6 +204,7 @@ public class ObjectFactory {
     private final static QName _Image_QNAME = new QName("https://bingads.microsoft.com/CampaignManagement/v13", "Image");
     private final static QName _TargetCpaBiddingScheme_QNAME = new QName("https://bingads.microsoft.com/CampaignManagement/v13", "TargetCpaBiddingScheme");
     private final static QName _AnyURI_QNAME = new QName("http://schemas.microsoft.com/2003/10/Serialization/", "anyURI");
+    private final static QName _CampaignConversionGoal_QNAME = new QName("https://bingads.microsoft.com/CampaignManagement/v13", "CampaignConversionGoal");
     private final static QName _Address_QNAME = new QName("https://bingads.microsoft.com/CampaignManagement/v13", "Address");
     private final static QName _CombinedList_QNAME = new QName("https://bingads.microsoft.com/CampaignManagement/v13", "CombinedList");
     private final static QName _ArrayOfAccountMigrationStatusesInfo_QNAME = new QName("https://bingads.microsoft.com/CampaignManagement/v13", "ArrayOfAccountMigrationStatusesInfo");
@@ -211,6 +213,7 @@ public class ObjectFactory {
     private final static QName _PlacementExclusionList_QNAME = new QName("https://bingads.microsoft.com/CampaignManagement/v13", "PlacementExclusionList");
     private final static QName _EditorialErrorCollection_QNAME = new QName("https://bingads.microsoft.com/CampaignManagement/v13", "EditorialErrorCollection");
     private final static QName _ArrayOfAdExtensionIdToEntityIdAssociation_QNAME = new QName("https://bingads.microsoft.com/CampaignManagement/v13", "ArrayOfAdExtensionIdToEntityIdAssociation");
+    private final static QName _ArrayOfCampaignConversionGoal_QNAME = new QName("https://bingads.microsoft.com/CampaignManagement/v13", "ArrayOfCampaignConversionGoal");
     private final static QName _AdExtensionEditorialReason_QNAME = new QName("https://bingads.microsoft.com/CampaignManagement/v13", "AdExtensionEditorialReason");
     private final static QName _Schedule_QNAME = new QName("https://bingads.microsoft.com/CampaignManagement/v13", "Schedule");
     private final static QName _GoogleImportOption_QNAME = new QName("https://bingads.microsoft.com/CampaignManagement/v13", "GoogleImportOption");
@@ -1558,6 +1561,14 @@ public class ObjectFactory {
     }
 
     /**
+     * Create an instance of {@link AddCampaignConversionGoalsResponse }
+     * 
+     */
+    public AddCampaignConversionGoalsResponse createAddCampaignConversionGoalsResponse() {
+        return new AddCampaignConversionGoalsResponse();
+    }
+
+    /**
      * Create an instance of {@link CriterionBid }
      * 
      */
@@ -1699,6 +1710,14 @@ public class ObjectFactory {
      */
     public CombinedList createCombinedList() {
         return new CombinedList();
+    }
+
+    /**
+     * Create an instance of {@link CampaignConversionGoal }
+     * 
+     */
+    public CampaignConversionGoal createCampaignConversionGoal() {
+        return new CampaignConversionGoal();
     }
 
     /**
@@ -2043,6 +2062,14 @@ public class ObjectFactory {
      */
     public DeleteAdExtensionsRequest createDeleteAdExtensionsRequest() {
         return new DeleteAdExtensionsRequest();
+    }
+
+    /**
+     * Create an instance of {@link DeleteCampaignConversionGoalsResponse }
+     * 
+     */
+    public DeleteCampaignConversionGoalsResponse createDeleteCampaignConversionGoalsResponse() {
+        return new DeleteCampaignConversionGoalsResponse();
     }
 
     /**
@@ -3614,6 +3641,14 @@ public class ObjectFactory {
     }
 
     /**
+     * Create an instance of {@link ArrayOfCampaignConversionGoal }
+     * 
+     */
+    public ArrayOfCampaignConversionGoal createArrayOfCampaignConversionGoal() {
+        return new ArrayOfCampaignConversionGoal();
+    }
+
+    /**
      * Create an instance of {@link UpdateAdGroupCriterionsRequest }
      * 
      */
@@ -3643,6 +3678,14 @@ public class ObjectFactory {
      */
     public GetAccountPropertiesResponse createGetAccountPropertiesResponse() {
         return new GetAccountPropertiesResponse();
+    }
+
+    /**
+     * Create an instance of {@link AddCampaignConversionGoalsRequest }
+     * 
+     */
+    public AddCampaignConversionGoalsRequest createAddCampaignConversionGoalsRequest() {
+        return new AddCampaignConversionGoalsRequest();
     }
 
     /**
@@ -3747,6 +3790,14 @@ public class ObjectFactory {
      */
     public GetNegativeSitesByCampaignIdsResponse createGetNegativeSitesByCampaignIdsResponse() {
         return new GetNegativeSitesByCampaignIdsResponse();
+    }
+
+    /**
+     * Create an instance of {@link DeleteCampaignConversionGoalsRequest }
+     * 
+     */
+    public DeleteCampaignConversionGoalsRequest createDeleteCampaignConversionGoalsRequest() {
+        return new DeleteCampaignConversionGoalsRequest();
     }
 
     /**
@@ -5193,6 +5244,15 @@ public class ObjectFactory {
     }
 
     /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AttributionModelType }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/CampaignManagement/v13", name = "AttributionModelType")
+    public JAXBElement<AttributionModelType> createAttributionModelType(AttributionModelType value) {
+        return new JAXBElement<AttributionModelType>(_AttributionModelType_QNAME, AttributionModelType.class, null, value);
+    }
+
+    /**
      * Create an instance of {@link JAXBElement }{@code <}{@link MigrationStatusInfo }{@code >}}
      * 
      */
@@ -6231,6 +6291,15 @@ public class ObjectFactory {
     }
 
     /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link CampaignConversionGoal }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/CampaignManagement/v13", name = "CampaignConversionGoal")
+    public JAXBElement<CampaignConversionGoal> createCampaignConversionGoal(CampaignConversionGoal value) {
+        return new JAXBElement<CampaignConversionGoal>(_CampaignConversionGoal_QNAME, CampaignConversionGoal.class, null, value);
+    }
+
+    /**
      * Create an instance of {@link JAXBElement }{@code <}{@link Address }{@code >}}
      * 
      */
@@ -6301,6 +6370,15 @@ public class ObjectFactory {
     @XmlElementDecl(namespace = "https://bingads.microsoft.com/CampaignManagement/v13", name = "ArrayOfAdExtensionIdToEntityIdAssociation")
     public JAXBElement<ArrayOfAdExtensionIdToEntityIdAssociation> createArrayOfAdExtensionIdToEntityIdAssociation(ArrayOfAdExtensionIdToEntityIdAssociation value) {
         return new JAXBElement<ArrayOfAdExtensionIdToEntityIdAssociation>(_ArrayOfAdExtensionIdToEntityIdAssociation_QNAME, ArrayOfAdExtensionIdToEntityIdAssociation.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfCampaignConversionGoal }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/CampaignManagement/v13", name = "ArrayOfCampaignConversionGoal")
+    public JAXBElement<ArrayOfCampaignConversionGoal> createArrayOfCampaignConversionGoal(ArrayOfCampaignConversionGoal value) {
+        return new JAXBElement<ArrayOfCampaignConversionGoal>(_ArrayOfCampaignConversionGoal_QNAME, ArrayOfCampaignConversionGoal.class, null, value);
     }
 
     /**

--- a/proxies/com/microsoft/bingads/v13/customerbilling/ICustomerBillingService.java
+++ b/proxies/com/microsoft/bingads/v13/customerbilling/ICustomerBillingService.java
@@ -56,9 +56,9 @@ public interface ICustomerBillingService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customerbilling.GetBillingDocumentsInfoResponse
+     * @throws ApiBatchFault_Exception
      * @throws AdApiFaultDetail_Exception
      * @throws ApiFault_Exception
-     * @throws ApiBatchFault_Exception
      */
     @WebMethod(operationName = "GetBillingDocumentsInfo", action = "GetBillingDocumentsInfo")
     @WebResult(name = "GetBillingDocumentsInfoResponse", targetNamespace = "https://bingads.microsoft.com/Billing/v13", partName = "parameters")
@@ -98,9 +98,9 @@ public interface ICustomerBillingService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customerbilling.GetBillingDocumentsResponse
+     * @throws ApiBatchFault_Exception
      * @throws AdApiFaultDetail_Exception
      * @throws ApiFault_Exception
-     * @throws ApiBatchFault_Exception
      */
     @WebMethod(operationName = "GetBillingDocuments", action = "GetBillingDocuments")
     @WebResult(name = "GetBillingDocumentsResponse", targetNamespace = "https://bingads.microsoft.com/Billing/v13", partName = "parameters")

--- a/proxies/com/microsoft/bingads/v13/customermanagement/ICustomerManagementService.java
+++ b/proxies/com/microsoft/bingads/v13/customermanagement/ICustomerManagementService.java
@@ -56,8 +56,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.GetAccountsInfoResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFault_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetAccountsInfo", action = "GetAccountsInfo")
     @WebResult(name = "GetAccountsInfoResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -97,8 +97,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.FindAccountsResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFault_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "FindAccounts", action = "FindAccounts")
     @WebResult(name = "FindAccountsResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -138,8 +138,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.AddAccountResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFault_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "AddAccount", action = "AddAccount")
     @WebResult(name = "AddAccountResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -179,8 +179,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.UpdateAccountResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFault_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "UpdateAccount", action = "UpdateAccount")
     @WebResult(name = "UpdateAccountResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -220,8 +220,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.GetCustomerResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFault_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetCustomer", action = "GetCustomer")
     @WebResult(name = "GetCustomerResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -261,8 +261,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.UpdateCustomerResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFault_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "UpdateCustomer", action = "UpdateCustomer")
     @WebResult(name = "UpdateCustomerResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -302,8 +302,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.SignupCustomerResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFault_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "SignupCustomer", action = "SignupCustomer")
     @WebResult(name = "SignupCustomerResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -343,8 +343,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.GetAccountResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFault_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetAccount", action = "GetAccount")
     @WebResult(name = "GetAccountResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -384,8 +384,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.GetCustomersInfoResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFault_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetCustomersInfo", action = "GetCustomersInfo")
     @WebResult(name = "GetCustomersInfoResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -425,8 +425,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.DeleteAccountResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFault_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "DeleteAccount", action = "DeleteAccount")
     @WebResult(name = "DeleteAccountResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -466,8 +466,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.DeleteCustomerResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFault_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "DeleteCustomer", action = "DeleteCustomer")
     @WebResult(name = "DeleteCustomerResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -507,8 +507,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.UpdateUserResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFault_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "UpdateUser", action = "UpdateUser")
     @WebResult(name = "UpdateUserResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -548,8 +548,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.UpdateUserRolesResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFault_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "UpdateUserRoles", action = "UpdateUserRoles")
     @WebResult(name = "UpdateUserRolesResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -589,8 +589,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.GetUserResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFault_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetUser", action = "GetUser")
     @WebResult(name = "GetUserResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -630,8 +630,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.GetCurrentUserResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFault_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetCurrentUser", action = "GetCurrentUser")
     @WebResult(name = "GetCurrentUserResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -671,8 +671,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.DeleteUserResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFault_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "DeleteUser", action = "DeleteUser")
     @WebResult(name = "DeleteUserResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -712,8 +712,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.GetUsersInfoResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFault_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetUsersInfo", action = "GetUsersInfo")
     @WebResult(name = "GetUsersInfoResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -753,8 +753,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.GetCustomerPilotFeaturesResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFault_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetCustomerPilotFeatures", action = "GetCustomerPilotFeatures")
     @WebResult(name = "GetCustomerPilotFeaturesResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -794,8 +794,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.GetAccountPilotFeaturesResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFault_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetAccountPilotFeatures", action = "GetAccountPilotFeatures")
     @WebResult(name = "GetAccountPilotFeaturesResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -835,8 +835,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.GetPilotFeaturesCountriesResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFault_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetPilotFeaturesCountries", action = "GetPilotFeaturesCountries")
     @WebResult(name = "GetPilotFeaturesCountriesResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -876,8 +876,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.GetAccessibleCustomerResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFault_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetAccessibleCustomer", action = "GetAccessibleCustomer")
     @WebResult(name = "GetAccessibleCustomerResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -917,8 +917,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.FindAccountsOrCustomersInfoResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFault_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "FindAccountsOrCustomersInfo", action = "FindAccountsOrCustomersInfo")
     @WebResult(name = "FindAccountsOrCustomersInfoResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -958,8 +958,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.UpgradeCustomerToAgencyResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFault_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "UpgradeCustomerToAgency", action = "UpgradeCustomerToAgency")
     @WebResult(name = "UpgradeCustomerToAgencyResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -999,8 +999,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.AddPrepayAccountResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFault_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "AddPrepayAccount", action = "AddPrepayAccount")
     @WebResult(name = "AddPrepayAccountResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -1040,8 +1040,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.UpdatePrepayAccountResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFault_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "UpdatePrepayAccount", action = "UpdatePrepayAccount")
     @WebResult(name = "UpdatePrepayAccountResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -1081,8 +1081,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.MapCustomerIdToExternalCustomerIdResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFault_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "MapCustomerIdToExternalCustomerId", action = "MapCustomerIdToExternalCustomerId")
     @WebResult(name = "MapCustomerIdToExternalCustomerIdResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -1122,8 +1122,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.MapAccountIdToExternalAccountIdsResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFault_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "MapAccountIdToExternalAccountIds", action = "MapAccountIdToExternalAccountIds")
     @WebResult(name = "MapAccountIdToExternalAccountIdsResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -1163,8 +1163,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.SearchCustomersResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFault_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "SearchCustomers", action = "SearchCustomers")
     @WebResult(name = "SearchCustomersResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -1204,8 +1204,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.AddClientLinksResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFault_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "AddClientLinks", action = "AddClientLinks")
     @WebResult(name = "AddClientLinksResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -1245,8 +1245,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.UpdateClientLinksResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFault_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "UpdateClientLinks", action = "UpdateClientLinks")
     @WebResult(name = "UpdateClientLinksResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -1286,8 +1286,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.SearchClientLinksResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFault_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "SearchClientLinks", action = "SearchClientLinks")
     @WebResult(name = "SearchClientLinksResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -1327,8 +1327,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.SearchAccountsResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFault_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "SearchAccounts", action = "SearchAccounts")
     @WebResult(name = "SearchAccountsResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -1368,8 +1368,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.SendUserInvitationResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFault_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "SendUserInvitation", action = "SendUserInvitation")
     @WebResult(name = "SendUserInvitationResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -1409,8 +1409,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.SearchUserInvitationsResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFault_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "SearchUserInvitations", action = "SearchUserInvitations")
     @WebResult(name = "SearchUserInvitationsResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -1450,8 +1450,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.ValidateAddressResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFault_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "ValidateAddress", action = "ValidateAddress")
     @WebResult(name = "ValidateAddressResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -1491,8 +1491,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.GetLinkedAccountsAndCustomersInfoResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFault_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetLinkedAccountsAndCustomersInfo", action = "GetLinkedAccountsAndCustomersInfo")
     @WebResult(name = "GetLinkedAccountsAndCustomersInfoResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -1532,8 +1532,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.GetUserMFAStatusResponse
-     * @throws AdApiFaultDetail_Exception
      * @throws ApiFault_Exception
+     * @throws AdApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetUserMFAStatus", action = "GetUserMFAStatus")
     @WebResult(name = "GetUserMFAStatusResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")

--- a/proxies/com/microsoft/bingads/v13/reporting/AccountPerformanceReportColumn.java
+++ b/proxies/com/microsoft/bingads/v13/reporting/AccountPerformanceReportColumn.java
@@ -85,6 +85,7 @@ import javax.xml.bind.annotation.XmlType;
  *     &lt;enumeration value="LowQualityConversionsQualified"/>
  *     &lt;enumeration value="AllConversionsQualified"/>
  *     &lt;enumeration value="ViewThroughConversionsQualified"/>
+ *     &lt;enumeration value="ViewThroughRevenue"/>
  *   &lt;/restriction>
  * &lt;/simpleType>
  * </pre>
@@ -235,7 +236,9 @@ public enum AccountPerformanceReportColumn {
     @XmlEnumValue("AllConversionsQualified")
     ALL_CONVERSIONS_QUALIFIED("AllConversionsQualified"),
     @XmlEnumValue("ViewThroughConversionsQualified")
-    VIEW_THROUGH_CONVERSIONS_QUALIFIED("ViewThroughConversionsQualified");
+    VIEW_THROUGH_CONVERSIONS_QUALIFIED("ViewThroughConversionsQualified"),
+    @XmlEnumValue("ViewThroughRevenue")
+    VIEW_THROUGH_REVENUE("ViewThroughRevenue");
     private final String value;
 
     AccountPerformanceReportColumn(String v) {

--- a/proxies/com/microsoft/bingads/v13/reporting/AdDynamicTextPerformanceReportColumn.java
+++ b/proxies/com/microsoft/bingads/v13/reporting/AdDynamicTextPerformanceReportColumn.java
@@ -68,6 +68,7 @@ import javax.xml.bind.annotation.XmlType;
  *     &lt;enumeration value="ConversionsQualified"/>
  *     &lt;enumeration value="AllConversionsQualified"/>
  *     &lt;enumeration value="ViewThroughConversionsQualified"/>
+ *     &lt;enumeration value="ViewThroughRevenue"/>
  *   &lt;/restriction>
  * &lt;/simpleType>
  * </pre>
@@ -184,7 +185,9 @@ public enum AdDynamicTextPerformanceReportColumn {
     @XmlEnumValue("AllConversionsQualified")
     ALL_CONVERSIONS_QUALIFIED("AllConversionsQualified"),
     @XmlEnumValue("ViewThroughConversionsQualified")
-    VIEW_THROUGH_CONVERSIONS_QUALIFIED("ViewThroughConversionsQualified");
+    VIEW_THROUGH_CONVERSIONS_QUALIFIED("ViewThroughConversionsQualified"),
+    @XmlEnumValue("ViewThroughRevenue")
+    VIEW_THROUGH_REVENUE("ViewThroughRevenue");
     private final String value;
 
     AdDynamicTextPerformanceReportColumn(String v) {

--- a/proxies/com/microsoft/bingads/v13/reporting/AdGroupPerformanceReportColumn.java
+++ b/proxies/com/microsoft/bingads/v13/reporting/AdGroupPerformanceReportColumn.java
@@ -99,6 +99,7 @@ import javax.xml.bind.annotation.XmlType;
  *     &lt;enumeration value="ConversionsQualified"/>
  *     &lt;enumeration value="AllConversionsQualified"/>
  *     &lt;enumeration value="ViewThroughConversionsQualified"/>
+ *     &lt;enumeration value="ViewThroughRevenue"/>
  *   &lt;/restriction>
  * &lt;/simpleType>
  * </pre>
@@ -277,7 +278,9 @@ public enum AdGroupPerformanceReportColumn {
     @XmlEnumValue("AllConversionsQualified")
     ALL_CONVERSIONS_QUALIFIED("AllConversionsQualified"),
     @XmlEnumValue("ViewThroughConversionsQualified")
-    VIEW_THROUGH_CONVERSIONS_QUALIFIED("ViewThroughConversionsQualified");
+    VIEW_THROUGH_CONVERSIONS_QUALIFIED("ViewThroughConversionsQualified"),
+    @XmlEnumValue("ViewThroughRevenue")
+    VIEW_THROUGH_REVENUE("ViewThroughRevenue");
     private final String value;
 
     AdGroupPerformanceReportColumn(String v) {

--- a/proxies/com/microsoft/bingads/v13/reporting/AdPerformanceReportColumn.java
+++ b/proxies/com/microsoft/bingads/v13/reporting/AdPerformanceReportColumn.java
@@ -91,6 +91,7 @@ import javax.xml.bind.annotation.XmlType;
  *     &lt;enumeration value="ConversionsQualified"/>
  *     &lt;enumeration value="AllConversionsQualified"/>
  *     &lt;enumeration value="ViewThroughConversionsQualified"/>
+ *     &lt;enumeration value="ViewThroughRevenue"/>
  *   &lt;/restriction>
  * &lt;/simpleType>
  * </pre>
@@ -253,7 +254,9 @@ public enum AdPerformanceReportColumn {
     @XmlEnumValue("AllConversionsQualified")
     ALL_CONVERSIONS_QUALIFIED("AllConversionsQualified"),
     @XmlEnumValue("ViewThroughConversionsQualified")
-    VIEW_THROUGH_CONVERSIONS_QUALIFIED("ViewThroughConversionsQualified");
+    VIEW_THROUGH_CONVERSIONS_QUALIFIED("ViewThroughConversionsQualified"),
+    @XmlEnumValue("ViewThroughRevenue")
+    VIEW_THROUGH_REVENUE("ViewThroughRevenue");
     private final String value;
 
     AdPerformanceReportColumn(String v) {

--- a/proxies/com/microsoft/bingads/v13/reporting/AgeGenderAudienceReportColumn.java
+++ b/proxies/com/microsoft/bingads/v13/reporting/AgeGenderAudienceReportColumn.java
@@ -47,6 +47,7 @@ import javax.xml.bind.annotation.XmlType;
  *     &lt;enumeration value="ConversionsQualified"/>
  *     &lt;enumeration value="AllConversionsQualified"/>
  *     &lt;enumeration value="ViewThroughConversionsQualified"/>
+ *     &lt;enumeration value="ViewThroughRevenue"/>
  *   &lt;/restriction>
  * &lt;/simpleType>
  * </pre>
@@ -121,7 +122,9 @@ public enum AgeGenderAudienceReportColumn {
     @XmlEnumValue("AllConversionsQualified")
     ALL_CONVERSIONS_QUALIFIED("AllConversionsQualified"),
     @XmlEnumValue("ViewThroughConversionsQualified")
-    VIEW_THROUGH_CONVERSIONS_QUALIFIED("ViewThroughConversionsQualified");
+    VIEW_THROUGH_CONVERSIONS_QUALIFIED("ViewThroughConversionsQualified"),
+    @XmlEnumValue("ViewThroughRevenue")
+    VIEW_THROUGH_REVENUE("ViewThroughRevenue");
     private final String value;
 
     AgeGenderAudienceReportColumn(String v) {

--- a/proxies/com/microsoft/bingads/v13/reporting/AudiencePerformanceReportColumn.java
+++ b/proxies/com/microsoft/bingads/v13/reporting/AudiencePerformanceReportColumn.java
@@ -61,6 +61,7 @@ import javax.xml.bind.annotation.XmlType;
  *     &lt;enumeration value="ConversionsQualified"/>
  *     &lt;enumeration value="AllConversionsQualified"/>
  *     &lt;enumeration value="ViewThroughConversionsQualified"/>
+ *     &lt;enumeration value="ViewThroughRevenue"/>
  *   &lt;/restriction>
  * &lt;/simpleType>
  * </pre>
@@ -163,7 +164,9 @@ public enum AudiencePerformanceReportColumn {
     @XmlEnumValue("AllConversionsQualified")
     ALL_CONVERSIONS_QUALIFIED("AllConversionsQualified"),
     @XmlEnumValue("ViewThroughConversionsQualified")
-    VIEW_THROUGH_CONVERSIONS_QUALIFIED("ViewThroughConversionsQualified");
+    VIEW_THROUGH_CONVERSIONS_QUALIFIED("ViewThroughConversionsQualified"),
+    @XmlEnumValue("ViewThroughRevenue")
+    VIEW_THROUGH_REVENUE("ViewThroughRevenue");
     private final String value;
 
     AudiencePerformanceReportColumn(String v) {

--- a/proxies/com/microsoft/bingads/v13/reporting/CampaignPerformanceReportColumn.java
+++ b/proxies/com/microsoft/bingads/v13/reporting/CampaignPerformanceReportColumn.java
@@ -106,6 +106,7 @@ import javax.xml.bind.annotation.XmlType;
  *     &lt;enumeration value="LowQualityConversionsQualified"/>
  *     &lt;enumeration value="AllConversionsQualified"/>
  *     &lt;enumeration value="ViewThroughConversionsQualified"/>
+ *     &lt;enumeration value="ViewThroughRevenue"/>
  *   &lt;/restriction>
  * &lt;/simpleType>
  * </pre>
@@ -298,7 +299,9 @@ public enum CampaignPerformanceReportColumn {
     @XmlEnumValue("AllConversionsQualified")
     ALL_CONVERSIONS_QUALIFIED("AllConversionsQualified"),
     @XmlEnumValue("ViewThroughConversionsQualified")
-    VIEW_THROUGH_CONVERSIONS_QUALIFIED("ViewThroughConversionsQualified");
+    VIEW_THROUGH_CONVERSIONS_QUALIFIED("ViewThroughConversionsQualified"),
+    @XmlEnumValue("ViewThroughRevenue")
+    VIEW_THROUGH_REVENUE("ViewThroughRevenue");
     private final String value;
 
     CampaignPerformanceReportColumn(String v) {

--- a/proxies/com/microsoft/bingads/v13/reporting/ConversionPerformanceReportColumn.java
+++ b/proxies/com/microsoft/bingads/v13/reporting/ConversionPerformanceReportColumn.java
@@ -54,6 +54,7 @@ import javax.xml.bind.annotation.XmlType;
  *     &lt;enumeration value="ConversionsQualified"/>
  *     &lt;enumeration value="AllConversionsQualified"/>
  *     &lt;enumeration value="ViewThroughConversionsQualified"/>
+ *     &lt;enumeration value="ViewThroughRevenue"/>
  *   &lt;/restriction>
  * &lt;/simpleType>
  * </pre>
@@ -142,7 +143,9 @@ public enum ConversionPerformanceReportColumn {
     @XmlEnumValue("AllConversionsQualified")
     ALL_CONVERSIONS_QUALIFIED("AllConversionsQualified"),
     @XmlEnumValue("ViewThroughConversionsQualified")
-    VIEW_THROUGH_CONVERSIONS_QUALIFIED("ViewThroughConversionsQualified");
+    VIEW_THROUGH_CONVERSIONS_QUALIFIED("ViewThroughConversionsQualified"),
+    @XmlEnumValue("ViewThroughRevenue")
+    VIEW_THROUGH_REVENUE("ViewThroughRevenue");
     private final String value;
 
     ConversionPerformanceReportColumn(String v) {

--- a/proxies/com/microsoft/bingads/v13/reporting/DSAAutoTargetPerformanceReportColumn.java
+++ b/proxies/com/microsoft/bingads/v13/reporting/DSAAutoTargetPerformanceReportColumn.java
@@ -68,6 +68,8 @@ import javax.xml.bind.annotation.XmlType;
  *     &lt;enumeration value="ConversionsQualified"/>
  *     &lt;enumeration value="AllConversionsQualified"/>
  *     &lt;enumeration value="ViewThroughConversionsQualified"/>
+ *     &lt;enumeration value="AdId"/>
+ *     &lt;enumeration value="ViewThroughRevenue"/>
  *   &lt;/restriction>
  * &lt;/simpleType>
  * </pre>
@@ -184,7 +186,11 @@ public enum DSAAutoTargetPerformanceReportColumn {
     @XmlEnumValue("AllConversionsQualified")
     ALL_CONVERSIONS_QUALIFIED("AllConversionsQualified"),
     @XmlEnumValue("ViewThroughConversionsQualified")
-    VIEW_THROUGH_CONVERSIONS_QUALIFIED("ViewThroughConversionsQualified");
+    VIEW_THROUGH_CONVERSIONS_QUALIFIED("ViewThroughConversionsQualified"),
+    @XmlEnumValue("AdId")
+    AD_ID("AdId"),
+    @XmlEnumValue("ViewThroughRevenue")
+    VIEW_THROUGH_REVENUE("ViewThroughRevenue");
     private final String value;
 
     DSAAutoTargetPerformanceReportColumn(String v) {

--- a/proxies/com/microsoft/bingads/v13/reporting/DSACategoryPerformanceReportColumn.java
+++ b/proxies/com/microsoft/bingads/v13/reporting/DSACategoryPerformanceReportColumn.java
@@ -66,6 +66,7 @@ import javax.xml.bind.annotation.XmlType;
  *     &lt;enumeration value="ConversionsQualified"/>
  *     &lt;enumeration value="AllConversionsQualified"/>
  *     &lt;enumeration value="ViewThroughConversionsQualified"/>
+ *     &lt;enumeration value="ViewThroughRevenue"/>
  *   &lt;/restriction>
  * &lt;/simpleType>
  * </pre>
@@ -178,7 +179,9 @@ public enum DSACategoryPerformanceReportColumn {
     @XmlEnumValue("AllConversionsQualified")
     ALL_CONVERSIONS_QUALIFIED("AllConversionsQualified"),
     @XmlEnumValue("ViewThroughConversionsQualified")
-    VIEW_THROUGH_CONVERSIONS_QUALIFIED("ViewThroughConversionsQualified");
+    VIEW_THROUGH_CONVERSIONS_QUALIFIED("ViewThroughConversionsQualified"),
+    @XmlEnumValue("ViewThroughRevenue")
+    VIEW_THROUGH_REVENUE("ViewThroughRevenue");
     private final String value;
 
     DSACategoryPerformanceReportColumn(String v) {

--- a/proxies/com/microsoft/bingads/v13/reporting/DSASearchQueryPerformanceReportColumn.java
+++ b/proxies/com/microsoft/bingads/v13/reporting/DSASearchQueryPerformanceReportColumn.java
@@ -71,6 +71,7 @@ import javax.xml.bind.annotation.XmlType;
  *     &lt;enumeration value="AverageCpm"/>
  *     &lt;enumeration value="ConversionsQualified"/>
  *     &lt;enumeration value="AllConversionsQualified"/>
+ *     &lt;enumeration value="Description"/>
  *   &lt;/restriction>
  * &lt;/simpleType>
  * </pre>
@@ -193,7 +194,9 @@ public enum DSASearchQueryPerformanceReportColumn {
     @XmlEnumValue("ConversionsQualified")
     CONVERSIONS_QUALIFIED("ConversionsQualified"),
     @XmlEnumValue("AllConversionsQualified")
-    ALL_CONVERSIONS_QUALIFIED("AllConversionsQualified");
+    ALL_CONVERSIONS_QUALIFIED("AllConversionsQualified"),
+    @XmlEnumValue("Description")
+    DESCRIPTION("Description");
     private final String value;
 
     DSASearchQueryPerformanceReportColumn(String v) {

--- a/proxies/com/microsoft/bingads/v13/reporting/DestinationUrlPerformanceReportColumn.java
+++ b/proxies/com/microsoft/bingads/v13/reporting/DestinationUrlPerformanceReportColumn.java
@@ -75,6 +75,7 @@ import javax.xml.bind.annotation.XmlType;
  *     &lt;enumeration value="ConversionsQualified"/>
  *     &lt;enumeration value="AllConversionsQualified"/>
  *     &lt;enumeration value="ViewThroughConversionsQualified"/>
+ *     &lt;enumeration value="ViewThroughRevenue"/>
  *   &lt;/restriction>
  * &lt;/simpleType>
  * </pre>
@@ -205,7 +206,9 @@ public enum DestinationUrlPerformanceReportColumn {
     @XmlEnumValue("AllConversionsQualified")
     ALL_CONVERSIONS_QUALIFIED("AllConversionsQualified"),
     @XmlEnumValue("ViewThroughConversionsQualified")
-    VIEW_THROUGH_CONVERSIONS_QUALIFIED("ViewThroughConversionsQualified");
+    VIEW_THROUGH_CONVERSIONS_QUALIFIED("ViewThroughConversionsQualified"),
+    @XmlEnumValue("ViewThroughRevenue")
+    VIEW_THROUGH_REVENUE("ViewThroughRevenue");
     private final String value;
 
     DestinationUrlPerformanceReportColumn(String v) {

--- a/proxies/com/microsoft/bingads/v13/reporting/GeographicPerformanceReportColumn.java
+++ b/proxies/com/microsoft/bingads/v13/reporting/GeographicPerformanceReportColumn.java
@@ -77,6 +77,7 @@ import javax.xml.bind.annotation.XmlType;
  *     &lt;enumeration value="AllConversionsQualified"/>
  *     &lt;enumeration value="ViewThroughConversionsQualified"/>
  *     &lt;enumeration value="Neighborhood"/>
+ *     &lt;enumeration value="ViewThroughRevenue"/>
  *   &lt;/restriction>
  * &lt;/simpleType>
  * </pre>
@@ -211,7 +212,9 @@ public enum GeographicPerformanceReportColumn {
     @XmlEnumValue("ViewThroughConversionsQualified")
     VIEW_THROUGH_CONVERSIONS_QUALIFIED("ViewThroughConversionsQualified"),
     @XmlEnumValue("Neighborhood")
-    NEIGHBORHOOD("Neighborhood");
+    NEIGHBORHOOD("Neighborhood"),
+    @XmlEnumValue("ViewThroughRevenue")
+    VIEW_THROUGH_REVENUE("ViewThroughRevenue");
     private final String value;
 
     GeographicPerformanceReportColumn(String v) {

--- a/proxies/com/microsoft/bingads/v13/reporting/GoalsAndFunnelsReportColumn.java
+++ b/proxies/com/microsoft/bingads/v13/reporting/GoalsAndFunnelsReportColumn.java
@@ -39,6 +39,7 @@ import javax.xml.bind.annotation.XmlType;
  *     &lt;enumeration value="ViewThroughConversions"/>
  *     &lt;enumeration value="AllConversionsQualified"/>
  *     &lt;enumeration value="ViewThroughConversionsQualified"/>
+ *     &lt;enumeration value="ViewThroughRevenue"/>
  *   &lt;/restriction>
  * &lt;/simpleType>
  * </pre>
@@ -97,7 +98,9 @@ public enum GoalsAndFunnelsReportColumn {
     @XmlEnumValue("AllConversionsQualified")
     ALL_CONVERSIONS_QUALIFIED("AllConversionsQualified"),
     @XmlEnumValue("ViewThroughConversionsQualified")
-    VIEW_THROUGH_CONVERSIONS_QUALIFIED("ViewThroughConversionsQualified");
+    VIEW_THROUGH_CONVERSIONS_QUALIFIED("ViewThroughConversionsQualified"),
+    @XmlEnumValue("ViewThroughRevenue")
+    VIEW_THROUGH_REVENUE("ViewThroughRevenue");
     private final String value;
 
     GoalsAndFunnelsReportColumn(String v) {

--- a/proxies/com/microsoft/bingads/v13/reporting/KeywordPerformanceReportColumn.java
+++ b/proxies/com/microsoft/bingads/v13/reporting/KeywordPerformanceReportColumn.java
@@ -92,6 +92,7 @@ import javax.xml.bind.annotation.XmlType;
  *     &lt;enumeration value="ConversionsQualified"/>
  *     &lt;enumeration value="AllConversionsQualified"/>
  *     &lt;enumeration value="ViewThroughConversionsQualified"/>
+ *     &lt;enumeration value="ViewThroughRevenue"/>
  *   &lt;/restriction>
  * &lt;/simpleType>
  * </pre>
@@ -256,7 +257,9 @@ public enum KeywordPerformanceReportColumn {
     @XmlEnumValue("AllConversionsQualified")
     ALL_CONVERSIONS_QUALIFIED("AllConversionsQualified"),
     @XmlEnumValue("ViewThroughConversionsQualified")
-    VIEW_THROUGH_CONVERSIONS_QUALIFIED("ViewThroughConversionsQualified");
+    VIEW_THROUGH_CONVERSIONS_QUALIFIED("ViewThroughConversionsQualified"),
+    @XmlEnumValue("ViewThroughRevenue")
+    VIEW_THROUGH_REVENUE("ViewThroughRevenue");
     private final String value;
 
     KeywordPerformanceReportColumn(String v) {

--- a/proxies/com/microsoft/bingads/v13/reporting/ProductDimensionPerformanceReportColumn.java
+++ b/proxies/com/microsoft/bingads/v13/reporting/ProductDimensionPerformanceReportColumn.java
@@ -102,6 +102,7 @@ import javax.xml.bind.annotation.XmlType;
  *     &lt;enumeration value="ProductBoughtTitle"/>
  *     &lt;enumeration value="GTIN"/>
  *     &lt;enumeration value="MPN"/>
+ *     &lt;enumeration value="ViewThroughRevenue"/>
  *   &lt;/restriction>
  * &lt;/simpleType>
  * </pre>
@@ -284,7 +285,9 @@ public enum ProductDimensionPerformanceReportColumn {
     @XmlEnumValue("ProductBoughtTitle")
     PRODUCT_BOUGHT_TITLE("ProductBoughtTitle"),
     GTIN("GTIN"),
-    MPN("MPN");
+    MPN("MPN"),
+    @XmlEnumValue("ViewThroughRevenue")
+    VIEW_THROUGH_REVENUE("ViewThroughRevenue");
     private final String value;
 
     ProductDimensionPerformanceReportColumn(String v) {

--- a/proxies/com/microsoft/bingads/v13/reporting/ProductPartitionPerformanceReportColumn.java
+++ b/proxies/com/microsoft/bingads/v13/reporting/ProductPartitionPerformanceReportColumn.java
@@ -88,6 +88,7 @@ import javax.xml.bind.annotation.XmlType;
  *     &lt;enumeration value="AssistedConversionsQualified"/>
  *     &lt;enumeration value="AllConversionsQualified"/>
  *     &lt;enumeration value="ViewThroughConversionsQualified"/>
+ *     &lt;enumeration value="ViewThroughRevenue"/>
  *   &lt;/restriction>
  * &lt;/simpleType>
  * </pre>
@@ -244,7 +245,9 @@ public enum ProductPartitionPerformanceReportColumn {
     @XmlEnumValue("AllConversionsQualified")
     ALL_CONVERSIONS_QUALIFIED("AllConversionsQualified"),
     @XmlEnumValue("ViewThroughConversionsQualified")
-    VIEW_THROUGH_CONVERSIONS_QUALIFIED("ViewThroughConversionsQualified");
+    VIEW_THROUGH_CONVERSIONS_QUALIFIED("ViewThroughConversionsQualified"),
+    @XmlEnumValue("ViewThroughRevenue")
+    VIEW_THROUGH_REVENUE("ViewThroughRevenue");
     private final String value;
 
     ProductPartitionPerformanceReportColumn(String v) {

--- a/proxies/com/microsoft/bingads/v13/reporting/ProductPartitionUnitPerformanceReportColumn.java
+++ b/proxies/com/microsoft/bingads/v13/reporting/ProductPartitionUnitPerformanceReportColumn.java
@@ -74,6 +74,7 @@ import javax.xml.bind.annotation.XmlType;
  *     &lt;enumeration value="AssistedConversionsQualified"/>
  *     &lt;enumeration value="AllConversionsQualified"/>
  *     &lt;enumeration value="ViewThroughConversionsQualified"/>
+ *     &lt;enumeration value="ViewThroughRevenue"/>
  *   &lt;/restriction>
  * &lt;/simpleType>
  * </pre>
@@ -202,7 +203,9 @@ public enum ProductPartitionUnitPerformanceReportColumn {
     @XmlEnumValue("AllConversionsQualified")
     ALL_CONVERSIONS_QUALIFIED("AllConversionsQualified"),
     @XmlEnumValue("ViewThroughConversionsQualified")
-    VIEW_THROUGH_CONVERSIONS_QUALIFIED("ViewThroughConversionsQualified");
+    VIEW_THROUGH_CONVERSIONS_QUALIFIED("ViewThroughConversionsQualified"),
+    @XmlEnumValue("ViewThroughRevenue")
+    VIEW_THROUGH_REVENUE("ViewThroughRevenue");
     private final String value;
 
     ProductPartitionUnitPerformanceReportColumn(String v) {

--- a/proxies/com/microsoft/bingads/v13/reporting/ProfessionalDemographicsAudienceReportColumn.java
+++ b/proxies/com/microsoft/bingads/v13/reporting/ProfessionalDemographicsAudienceReportColumn.java
@@ -47,6 +47,7 @@ import javax.xml.bind.annotation.XmlType;
  *     &lt;enumeration value="ConversionsQualified"/>
  *     &lt;enumeration value="AllConversionsQualified"/>
  *     &lt;enumeration value="ViewThroughConversionsQualified"/>
+ *     &lt;enumeration value="ViewThroughRevenue"/>
  *   &lt;/restriction>
  * &lt;/simpleType>
  * </pre>
@@ -121,7 +122,9 @@ public enum ProfessionalDemographicsAudienceReportColumn {
     @XmlEnumValue("AllConversionsQualified")
     ALL_CONVERSIONS_QUALIFIED("AllConversionsQualified"),
     @XmlEnumValue("ViewThroughConversionsQualified")
-    VIEW_THROUGH_CONVERSIONS_QUALIFIED("ViewThroughConversionsQualified");
+    VIEW_THROUGH_CONVERSIONS_QUALIFIED("ViewThroughConversionsQualified"),
+    @XmlEnumValue("ViewThroughRevenue")
+    VIEW_THROUGH_REVENUE("ViewThroughRevenue");
     private final String value;
 
     ProfessionalDemographicsAudienceReportColumn(String v) {

--- a/proxies/com/microsoft/bingads/v13/reporting/PublisherUsagePerformanceReportColumn.java
+++ b/proxies/com/microsoft/bingads/v13/reporting/PublisherUsagePerformanceReportColumn.java
@@ -65,6 +65,7 @@ import javax.xml.bind.annotation.XmlType;
  *     &lt;enumeration value="ConversionsQualified"/>
  *     &lt;enumeration value="AllConversionsQualified"/>
  *     &lt;enumeration value="ViewThroughConversionsQualified"/>
+ *     &lt;enumeration value="ViewThroughRevenue"/>
  *   &lt;/restriction>
  * &lt;/simpleType>
  * </pre>
@@ -175,7 +176,9 @@ public enum PublisherUsagePerformanceReportColumn {
     @XmlEnumValue("AllConversionsQualified")
     ALL_CONVERSIONS_QUALIFIED("AllConversionsQualified"),
     @XmlEnumValue("ViewThroughConversionsQualified")
-    VIEW_THROUGH_CONVERSIONS_QUALIFIED("ViewThroughConversionsQualified");
+    VIEW_THROUGH_CONVERSIONS_QUALIFIED("ViewThroughConversionsQualified"),
+    @XmlEnumValue("ViewThroughRevenue")
+    VIEW_THROUGH_REVENUE("ViewThroughRevenue");
     private final String value;
 
     PublisherUsagePerformanceReportColumn(String v) {

--- a/proxies/com/microsoft/bingads/v13/reporting/ShareOfVoiceReportColumn.java
+++ b/proxies/com/microsoft/bingads/v13/reporting/ShareOfVoiceReportColumn.java
@@ -74,6 +74,7 @@ import javax.xml.bind.annotation.XmlType;
  *     &lt;enumeration value="ConversionsQualified"/>
  *     &lt;enumeration value="AllConversionsQualified"/>
  *     &lt;enumeration value="ViewThroughConversionsQualified"/>
+ *     &lt;enumeration value="ViewThroughRevenue"/>
  *   &lt;/restriction>
  * &lt;/simpleType>
  * </pre>
@@ -202,7 +203,9 @@ public enum ShareOfVoiceReportColumn {
     @XmlEnumValue("AllConversionsQualified")
     ALL_CONVERSIONS_QUALIFIED("AllConversionsQualified"),
     @XmlEnumValue("ViewThroughConversionsQualified")
-    VIEW_THROUGH_CONVERSIONS_QUALIFIED("ViewThroughConversionsQualified");
+    VIEW_THROUGH_CONVERSIONS_QUALIFIED("ViewThroughConversionsQualified"),
+    @XmlEnumValue("ViewThroughRevenue")
+    VIEW_THROUGH_REVENUE("ViewThroughRevenue");
     private final String value;
 
     ShareOfVoiceReportColumn(String v) {

--- a/proxies/com/microsoft/bingads/v13/reporting/UserLocationPerformanceReportColumn.java
+++ b/proxies/com/microsoft/bingads/v13/reporting/UserLocationPerformanceReportColumn.java
@@ -79,6 +79,7 @@ import javax.xml.bind.annotation.XmlType;
  *     &lt;enumeration value="ViewThroughConversionsQualified"/>
  *     &lt;enumeration value="Neighborhood"/>
  *     &lt;enumeration value="QueryIntentNeighborhood"/>
+ *     &lt;enumeration value="ViewThroughRevenue"/>
  *   &lt;/restriction>
  * &lt;/simpleType>
  * </pre>
@@ -217,7 +218,9 @@ public enum UserLocationPerformanceReportColumn {
     @XmlEnumValue("Neighborhood")
     NEIGHBORHOOD("Neighborhood"),
     @XmlEnumValue("QueryIntentNeighborhood")
-    QUERY_INTENT_NEIGHBORHOOD("QueryIntentNeighborhood");
+    QUERY_INTENT_NEIGHBORHOOD("QueryIntentNeighborhood"),
+    @XmlEnumValue("ViewThroughRevenue")
+    VIEW_THROUGH_REVENUE("ViewThroughRevenue");
     private final String value;
 
     UserLocationPerformanceReportColumn(String v) {

--- a/proxies/generateAllServiceProxies.bat
+++ b/proxies/generateAllServiceProxies.bat
@@ -6,12 +6,12 @@ if exist ..\tools\WsdlEnumGenerator\bin\Debug\net48\WsdlEnumGenerator.exe (
 	del jaxb-bindings-v13.adinsight.xml
 	del jaxb-bindings-v13.bulk.xml
 	
-	REM call generateProxy v13.customerbilling https://clientcenter.api.sandbox.bingads.microsoft.com/Api/Billing/v13/CustomerBillingService.svc
-	REM call generateProxy v13.customermanagement https://clientcenter.api.sandbox.bingads.microsoft.com/Api/CustomerManagement/v13/CustomerManagementService.svc
-	REM call generateProxy v13.reporting https://reporting.api.sandbox.bingads.microsoft.com/Api/Advertiser/Reporting/v13/ReportingService.svc
+	call generateProxy v13.customerbilling https://clientcenter.api.sandbox.bingads.microsoft.com/Api/Billing/v13/CustomerBillingService.svc
+	call generateProxy v13.customermanagement https://clientcenter.api.sandbox.bingads.microsoft.com/Api/CustomerManagement/v13/CustomerManagementService.svc
+	call generateProxy v13.reporting https://reporting.api.sandbox.bingads.microsoft.com/Api/Advertiser/Reporting/v13/ReportingService.svc
 	call generateProxy v13.campaignmanagement https://campaign.api.sandbox.bingads.microsoft.com/Api/Advertiser/CampaignManagement/v13/CampaignManagementService.svc
-	REM call generateProxy v13.bulk https://bulk.api.sandbox.bingads.microsoft.com/Api/Advertiser/CampaignManagement/v13/BulkService.svc
-	REM call generateProxy v13.adinsight https://adinsight.api.sandbox.bingads.microsoft.com/Api/Advertiser/AdInsight/v13/AdInsightService.svc
+	call generateProxy v13.bulk https://bulk.api.sandbox.bingads.microsoft.com/Api/Advertiser/CampaignManagement/v13/BulkService.svc
+	call generateProxy v13.adinsight https://adinsight.api.sandbox.bingads.microsoft.com/Api/Advertiser/AdInsight/v13/AdInsightService.svc
 	
 ) else (	
 	echo Please build ..\tools\WsdlEnumGenerator\WsdlEnumGenerator.csproj first	

--- a/src/main/java/com/microsoft/bingads/internal/ServiceFactoryImpl.java
+++ b/src/main/java/com/microsoft/bingads/internal/ServiceFactoryImpl.java
@@ -29,7 +29,7 @@ import com.microsoft.bingads.InternalException;
 
 public class ServiceFactoryImpl implements ServiceFactory {
 
-    private static final String VERSION = "13.0.13";
+    private static final String VERSION = "13.0.14";
     
     private static final int DEFAULT_WS_CREATE_TIMEOUT_IN_SECOND = 60;
     

--- a/src/main/java/com/microsoft/bingads/v13/bulk/entities/AttributeType.java
+++ b/src/main/java/com/microsoft/bingads/v13/bulk/entities/AttributeType.java
@@ -1,0 +1,31 @@
+package com.microsoft.bingads.v13.bulk.entities;
+
+/**
+ * Provides possible attribute types for bulk Ad Customizer Attributes.
+ */
+public enum AttributeType {
+	UNKNOW("Unknow"),
+	NUMBER("Number"),
+	STRING("String"),
+	PRICE("Price"),
+	PERCENT("Percent");
+	
+	private final String value;
+
+	AttributeType(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    public static AttributeType fromValue(String v) {
+        for (AttributeType c : AttributeType.values()) {
+            if (c.value.equals(v)) {
+                return c;
+            }
+        }
+        throw new IllegalArgumentException(v);
+    }
+}

--- a/src/main/java/com/microsoft/bingads/v13/bulk/entities/BulkAdCustomizerAttribute.java
+++ b/src/main/java/com/microsoft/bingads/v13/bulk/entities/BulkAdCustomizerAttribute.java
@@ -1,0 +1,213 @@
+package com.microsoft.bingads.v13.bulk.entities;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import com.microsoft.bingads.internal.functionalinterfaces.BiConsumer;
+import com.microsoft.bingads.internal.functionalinterfaces.Function;
+import com.microsoft.bingads.v13.bulk.BulkFileReader;
+import com.microsoft.bingads.v13.bulk.BulkFileWriter;
+import com.microsoft.bingads.v13.bulk.BulkOperation;
+import com.microsoft.bingads.v13.bulk.BulkServiceManager;
+import com.microsoft.bingads.v13.internal.bulk.BulkMapping;
+import com.microsoft.bingads.v13.internal.bulk.MappingHelpers;
+import com.microsoft.bingads.v13.internal.bulk.RowValues;
+import com.microsoft.bingads.v13.internal.bulk.SimpleBulkMapping;
+import com.microsoft.bingads.v13.internal.bulk.StringExtensions;
+import com.microsoft.bingads.v13.internal.bulk.StringTable;
+import com.microsoft.bingads.v13.internal.bulk.entities.SingleRecordBulkEntity;
+
+/**
+ * Represents an Ad Customizer Attribute that can be read or written in a bulk file.
+ * <p/>
+ * <p>
+ * For more information, see Ad Customizer Attribute at
+ * <a href="https://go.microsoft.com/fwlink/?linkid=846127">https://go.microsoft.com/fwlink/?linkid=846127</a>.
+ * </p>
+ *
+ * @see BulkServiceManager
+ * @see BulkOperation
+ * @see BulkFileReader
+ * @see BulkFileWriter
+ */
+public class BulkAdCustomizerAttribute extends SingleRecordBulkEntity {
+	
+	private String id;
+	
+	private String name;
+	
+	private String accountValue;
+	
+	private AttributeType dataType;
+	
+	private EditorialStatus editorialStatus;
+	
+	private String status;
+	
+	private static final List<BulkMapping<BulkAdCustomizerAttribute>> MAPPINGS;
+	
+	static {
+		List<BulkMapping<BulkAdCustomizerAttribute>> m = new ArrayList<BulkMapping<BulkAdCustomizerAttribute>>();
+		
+		m.add(new SimpleBulkMapping<BulkAdCustomizerAttribute, String>(StringTable.Id,
+                new Function<BulkAdCustomizerAttribute, String>() {
+					@Override
+					public String apply(BulkAdCustomizerAttribute t) {
+						return t.getId();
+					}
+				},
+                new BiConsumer<String, BulkAdCustomizerAttribute>() {
+                    @Override
+                    public void accept(String v, BulkAdCustomizerAttribute c) {
+                        c.setId(v);
+                    }
+                }
+        ));
+		
+		m.add(new SimpleBulkMapping<BulkAdCustomizerAttribute, String>(StringTable.Name,
+                new Function<BulkAdCustomizerAttribute, String>() {
+					@Override
+					public String apply(BulkAdCustomizerAttribute t) {
+						return t.getName();
+					}
+				},
+                new BiConsumer<String, BulkAdCustomizerAttribute>() {
+                    @Override
+                    public void accept(String v, BulkAdCustomizerAttribute c) {
+                        c.setName(v);
+                    }
+                }
+        ));
+		
+		m.add(new SimpleBulkMapping<BulkAdCustomizerAttribute, String>(StringTable.AdCustomizerAttributeValue,
+                new Function<BulkAdCustomizerAttribute, String>() {
+					@Override
+					public String apply(BulkAdCustomizerAttribute t) {
+						return t.getAccountValue();
+					}
+				},
+                new BiConsumer<String, BulkAdCustomizerAttribute>() {
+                    @Override
+                    public void accept(String v, BulkAdCustomizerAttribute c) {
+                        c.setAccountValue(v);
+                    }
+                }
+        ));
+		
+		m.add(new SimpleBulkMapping<BulkAdCustomizerAttribute, String>(StringTable.AdCustomizerDataType,
+                new Function<BulkAdCustomizerAttribute, String>() {
+					@Override
+					public String apply(BulkAdCustomizerAttribute t) {
+						return t.getDataType() != null ? t.getDataType().value() : null;
+					}
+				},
+                new BiConsumer<String, BulkAdCustomizerAttribute>() {
+					@Override
+					public void accept(String v, BulkAdCustomizerAttribute t) {
+						t.setDataType(StringExtensions.parseOptional(v, new Function<String, AttributeType>() {
+							@Override
+							public AttributeType apply(String value) {
+								return AttributeType.fromValue(value);
+							}
+						}));
+					}
+                }
+        ));
+		
+		m.add(new SimpleBulkMapping<BulkAdCustomizerAttribute, String>(StringTable.EditorialStatus,
+                new Function<BulkAdCustomizerAttribute, String>() {
+					@Override
+					public String apply(BulkAdCustomizerAttribute t) {
+						return t.getEditorialStatus() != null ? t.getEditorialStatus().value() : null;
+					}
+				},
+                new BiConsumer<String, BulkAdCustomizerAttribute>() {
+					@Override
+					public void accept(String v, BulkAdCustomizerAttribute t) {
+						t.setEditorialStatus(StringExtensions.parseOptional(v, new Function<String, EditorialStatus>() {
+							@Override
+							public EditorialStatus apply(String value) {
+								return EditorialStatus.fromValue(value);
+							}
+						}));
+					}
+                }
+        ));
+		
+		m.add(new SimpleBulkMapping<BulkAdCustomizerAttribute, String>(StringTable.Status,
+                new Function<BulkAdCustomizerAttribute, String>() {
+					@Override
+					public String apply(BulkAdCustomizerAttribute t) {
+						return t.getStatus();
+					}
+				},
+                new BiConsumer<String, BulkAdCustomizerAttribute>() {
+                    @Override
+                    public void accept(String v, BulkAdCustomizerAttribute c) {
+                        c.setStatus(v);
+                    }
+                }
+        ));
+		
+		MAPPINGS = Collections.unmodifiableList(m);
+	}
+
+	public String getId() {
+		return id;
+	}
+	
+	public void setId(String id) {
+		this.id = id;
+	}
+	
+	public String getName() {
+		return name;
+	}
+	
+	public void setName(String name) {
+		this.name = name;
+	}
+	
+	public String getAccountValue() {
+		return accountValue;
+	}
+	
+	public void setAccountValue(String accountValue) {
+		this.accountValue = accountValue;
+	}
+	
+	public AttributeType getDataType() {
+		return dataType;
+	}
+	
+	public void setDataType(AttributeType dataType) {
+		this.dataType = dataType;
+	}
+	
+	public EditorialStatus getEditorialStatus() {
+		return editorialStatus;
+	}
+	
+	public void setEditorialStatus(EditorialStatus editorialStatus) {
+		this.editorialStatus = editorialStatus;
+	}
+	
+	public String getStatus() {
+		return status;
+	}
+
+	public void setStatus(String status) {
+		this.status = status;
+	}
+	
+	@Override
+	public void processMappingsFromRowValues(RowValues values) {
+		MappingHelpers.<BulkAdCustomizerAttribute>convertToEntity(values, MAPPINGS, this);
+	}
+
+	@Override
+	public void processMappingsToRowValues(RowValues values, boolean excludeReadonlyData) {
+		MappingHelpers.convertToValues(this, values, MAPPINGS);
+	}
+}

--- a/src/main/java/com/microsoft/bingads/v13/bulk/entities/BulkAdCustomizerAttributeEntityBase.java
+++ b/src/main/java/com/microsoft/bingads/v13/bulk/entities/BulkAdCustomizerAttributeEntityBase.java
@@ -1,0 +1,181 @@
+package com.microsoft.bingads.v13.bulk.entities;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import com.microsoft.bingads.internal.functionalinterfaces.BiConsumer;
+import com.microsoft.bingads.internal.functionalinterfaces.Function;
+import com.microsoft.bingads.v13.internal.bulk.BulkMapping;
+import com.microsoft.bingads.v13.internal.bulk.MappingHelpers;
+import com.microsoft.bingads.v13.internal.bulk.RowValues;
+import com.microsoft.bingads.v13.internal.bulk.SimpleBulkMapping;
+import com.microsoft.bingads.v13.internal.bulk.StringExtensions;
+import com.microsoft.bingads.v13.internal.bulk.StringTable;
+import com.microsoft.bingads.v13.internal.bulk.entities.SingleRecordBulkEntity;
+
+/**
+ * Base class for all Ad Customizer Attribute subclasses that can be read
+ * or written in a bulk file.
+ *
+ * @see BulkCampaignAdCustomizerAttribute
+ * @see BulkAdGroupAdCustomizerAttribute
+ * @see BulkKeywordAdCustomizerAttribute
+ */
+public class BulkAdCustomizerAttributeEntityBase extends SingleRecordBulkEntity {
+
+	protected String id;
+	
+	protected String name;
+	
+	protected long parentId;
+	
+	protected String attributeValue;
+	
+	protected EditorialStatus editorialStatus;
+	
+	protected static final List<BulkMapping<BulkAdCustomizerAttributeEntityBase>> MAPPINGS;
+	
+	static {
+		List<BulkMapping<BulkAdCustomizerAttributeEntityBase>> m = new ArrayList<BulkMapping<BulkAdCustomizerAttributeEntityBase>>();
+		
+		m.add(new SimpleBulkMapping<BulkAdCustomizerAttributeEntityBase, String>(StringTable.Id,
+                new Function<BulkAdCustomizerAttributeEntityBase, String>() {
+					@Override
+					public String apply(BulkAdCustomizerAttributeEntityBase t) {
+						return t.getId();
+					}
+				},
+                new BiConsumer<String, BulkAdCustomizerAttributeEntityBase>() {
+                    @Override
+                    public void accept(String v, BulkAdCustomizerAttributeEntityBase c) {
+                        c.setId(v);
+                    }
+                }
+        ));
+		
+		m.add(new SimpleBulkMapping<BulkAdCustomizerAttributeEntityBase, String>(StringTable.Name,
+                new Function<BulkAdCustomizerAttributeEntityBase, String>() {
+					@Override
+					public String apply(BulkAdCustomizerAttributeEntityBase t) {
+						return t.getName();
+					}
+				},
+                new BiConsumer<String, BulkAdCustomizerAttributeEntityBase>() {
+                    @Override
+                    public void accept(String v, BulkAdCustomizerAttributeEntityBase c) {
+                        c.setName(v);
+                    }
+                }
+        ));
+		
+		m.add(new SimpleBulkMapping<BulkAdCustomizerAttributeEntityBase, Long>(StringTable.ParentId,
+                new Function<BulkAdCustomizerAttributeEntityBase, Long>() {
+                    @Override
+                    public Long apply(BulkAdCustomizerAttributeEntityBase t) {
+                        return t.getParentId();
+                    }
+                },
+                new BiConsumer<String, BulkAdCustomizerAttributeEntityBase>() {
+                    @Override
+                    public void accept(String v, BulkAdCustomizerAttributeEntityBase c) {
+                        c.setParentId(StringExtensions.<Long>parseOptional(v, new Function<String, Long>() {
+                            @Override
+                            public Long apply(String value) {
+                                return Long.parseLong(value);
+                            }
+                        }));
+                    }
+                }
+        ));
+		
+		m.add(new SimpleBulkMapping<BulkAdCustomizerAttributeEntityBase, String>(StringTable.AdCustomizerAttributeValue,
+                new Function<BulkAdCustomizerAttributeEntityBase, String>() {
+					@Override
+					public String apply(BulkAdCustomizerAttributeEntityBase t) {
+						return t.getAttributeValue();
+					}
+				},
+                new BiConsumer<String, BulkAdCustomizerAttributeEntityBase>() {
+                    @Override
+                    public void accept(String v, BulkAdCustomizerAttributeEntityBase c) {
+                        c.setAttributeValue(v);
+                    }
+                }
+        ));
+		
+		m.add(new SimpleBulkMapping<BulkAdCustomizerAttributeEntityBase, String>(StringTable.EditorialStatus,
+                new Function<BulkAdCustomizerAttributeEntityBase, String>() {
+					@Override
+					public String apply(BulkAdCustomizerAttributeEntityBase t) {
+						return t.getEditorialStatus() != null ? t.getEditorialStatus().value() : null;
+					}
+				},
+                new BiConsumer<String, BulkAdCustomizerAttributeEntityBase>() {
+					@Override
+					public void accept(String v, BulkAdCustomizerAttributeEntityBase c) {
+						c.setEditorialStatus(StringExtensions.parseOptional(v, new Function<String, EditorialStatus>() {
+							@Override
+							public EditorialStatus apply(String value) {
+								return EditorialStatus.fromValue(value);
+							}
+						}));
+					}
+                }
+        ));
+		
+		MAPPINGS = Collections.unmodifiableList(m);
+	}
+
+	public String getId() {
+		return id;
+	}
+	
+	public void setId(String id) {
+		this.id = id;
+	}
+	
+	public String getName() {
+		return name;
+	}
+	
+	public void setName(String name) {
+		this.name = name;
+	}
+	
+	public long getParentId() {
+		return parentId;
+	}
+
+	public void setParentId(long parentId) {
+		this.parentId = parentId;
+	}
+
+	public String getAttributeValue() {
+		return attributeValue;
+	}
+	
+	public void setAttributeValue(String attributeValue) {
+		this.attributeValue = attributeValue;
+	}
+	
+	public EditorialStatus getEditorialStatus() {
+		return editorialStatus;
+	}
+	
+	public void setEditorialStatus(EditorialStatus editorialStatus) {
+		this.editorialStatus = editorialStatus;
+	}
+	
+	
+	@Override
+	public void processMappingsFromRowValues(RowValues values) {
+		MappingHelpers.<BulkAdCustomizerAttributeEntityBase>convertToEntity(values, MAPPINGS, this);
+	}
+
+	@Override
+	public void processMappingsToRowValues(RowValues values, boolean excludeReadonlyData) {
+		MappingHelpers.convertToValues(this, values, MAPPINGS);
+	}
+
+}

--- a/src/main/java/com/microsoft/bingads/v13/bulk/entities/BulkAdGroupAdCustomizerAttribute.java
+++ b/src/main/java/com/microsoft/bingads/v13/bulk/entities/BulkAdGroupAdCustomizerAttribute.java
@@ -1,0 +1,31 @@
+package com.microsoft.bingads.v13.bulk.entities;
+
+import com.microsoft.bingads.v13.bulk.BulkFileReader;
+import com.microsoft.bingads.v13.bulk.BulkFileWriter;
+import com.microsoft.bingads.v13.bulk.BulkOperation;
+import com.microsoft.bingads.v13.bulk.BulkServiceManager;
+
+/**
+ * Represents an Ad Group Ad Customizer Attribute that can be read or written in a bulk file.
+ * <p/>
+ * <p>
+ * For more information, see Ad Group Ad Customizer Attribute at
+ * <a href="https://go.microsoft.com/fwlink/?linkid=846127">https://go.microsoft.com/fwlink/?linkid=846127</a>.
+ * </p>
+ *
+ * @see BulkServiceManager
+ * @see BulkOperation
+ * @see BulkFileReader
+ * @see BulkFileWriter
+ */
+public class BulkAdGroupAdCustomizerAttribute extends BulkAdCustomizerAttributeEntityBase {
+
+	public Long getAdGroupId() {
+		return parentId;
+	}
+	
+	public void setAdGroupId(long adGroupId) {
+		this.parentId = adGroupId;
+	}
+
+}

--- a/src/main/java/com/microsoft/bingads/v13/bulk/entities/BulkCampaignAdCustomizerAttribute.java
+++ b/src/main/java/com/microsoft/bingads/v13/bulk/entities/BulkCampaignAdCustomizerAttribute.java
@@ -1,0 +1,31 @@
+package com.microsoft.bingads.v13.bulk.entities;
+
+import com.microsoft.bingads.v13.bulk.BulkFileReader;
+import com.microsoft.bingads.v13.bulk.BulkFileWriter;
+import com.microsoft.bingads.v13.bulk.BulkOperation;
+import com.microsoft.bingads.v13.bulk.BulkServiceManager;
+
+/**
+ * Represents a Campaign Ad Customizer Attribute that can be read or written in a bulk file.
+ * <p/>
+ * <p>
+ * For more information, see Campaign Ad Customizer Attribute at
+ * <a href="https://go.microsoft.com/fwlink/?linkid=846127">https://go.microsoft.com/fwlink/?linkid=846127</a>.
+ * </p>
+ *
+ * @see BulkServiceManager
+ * @see BulkOperation
+ * @see BulkFileReader
+ * @see BulkFileWriter
+ */
+public class BulkCampaignAdCustomizerAttribute extends BulkAdCustomizerAttributeEntityBase {
+	
+	public Long getCampaignId() {
+		return parentId;
+	}
+	
+	public void setCampaignId(long campaignId) {
+		this.parentId = campaignId;
+	}
+
+}

--- a/src/main/java/com/microsoft/bingads/v13/bulk/entities/BulkCampaignConversionGoal.java
+++ b/src/main/java/com/microsoft/bingads/v13/bulk/entities/BulkCampaignConversionGoal.java
@@ -1,0 +1,108 @@
+package com.microsoft.bingads.v13.bulk.entities;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import com.microsoft.bingads.internal.functionalinterfaces.BiConsumer;
+import com.microsoft.bingads.internal.functionalinterfaces.Function;
+import com.microsoft.bingads.v13.campaignmanagement.CampaignConversionGoal;
+import com.microsoft.bingads.v13.internal.bulk.BulkMapping;
+import com.microsoft.bingads.v13.internal.bulk.MappingHelpers;
+import com.microsoft.bingads.v13.internal.bulk.RowValues;
+import com.microsoft.bingads.v13.internal.bulk.SimpleBulkMapping;
+import com.microsoft.bingads.v13.internal.bulk.StringExtensions;
+import com.microsoft.bingads.v13.internal.bulk.StringTable;
+import com.microsoft.bingads.v13.internal.bulk.entities.SingleRecordBulkEntity;
+
+/**
+ * This abstract class provides properties that are shared by all bulk campaign conversion goal classes.
+ */
+public class BulkCampaignConversionGoal extends SingleRecordBulkEntity {
+    
+    private CampaignConversionGoal campaignConversionGoal;
+
+    private static final List<BulkMapping<BulkCampaignConversionGoal>> MAPPINGS;
+
+    static {
+        List<BulkMapping<BulkCampaignConversionGoal>> m = new ArrayList<BulkMapping<BulkCampaignConversionGoal>>();
+
+        m.add(new SimpleBulkMapping<BulkCampaignConversionGoal, Long>(StringTable.ParentId,
+                new Function<BulkCampaignConversionGoal, Long>() {
+                    @Override
+                    public Long apply(BulkCampaignConversionGoal g) {
+                        return g.getCampaignConversionGoal().getCampaignId();
+                    }
+                },
+                new BiConsumer<String, BulkCampaignConversionGoal>() {
+                    @Override
+                    public void accept(String v, BulkCampaignConversionGoal g) {
+                        g.getCampaignConversionGoal().setCampaignId(StringExtensions.<Long>parseOptional(v, new Function<String, Long>() {
+                            @Override
+                            public Long apply(String value) {
+                                return Long.parseLong(value);
+                            }
+                        }));
+                    }
+                }
+        ));
+        
+        m.add(new SimpleBulkMapping<BulkCampaignConversionGoal, Long>(StringTable.GoalId,
+                new Function<BulkCampaignConversionGoal, Long>() {
+                    @Override
+                    public Long apply(BulkCampaignConversionGoal g) {
+                        return g.getCampaignConversionGoal().getGoalId();
+                    }
+                },
+                new BiConsumer<String, BulkCampaignConversionGoal>() {
+                    @Override
+                    public void accept(String v, BulkCampaignConversionGoal g) {
+                        g.getCampaignConversionGoal().setGoalId(StringExtensions.<Long>parseOptional(v, new Function<String, Long>() {
+                            @Override
+                            public Long apply(String value) {
+                                return Long.parseLong(value);
+                            }
+                        }));
+                    }
+                }
+        ));
+
+        MAPPINGS = Collections.unmodifiableList(m);
+    }
+
+    @Override
+    public void processMappingsFromRowValues(RowValues values) {
+        this.setCampaignConversionGoal(new CampaignConversionGoal());
+        MappingHelpers.convertToEntity(values, MAPPINGS, this);
+
+    }
+
+    @Override
+    public void processMappingsToRowValues(RowValues values, boolean excludeReadonlyData) {
+        validatePropertyNotNull(getCampaignConversionGoal(), "CampaignConversionGoal");
+
+        MappingHelpers.convertToValues(this, values, MAPPINGS);
+    }
+    
+    public CampaignConversionGoal createCampaignConversionGoal()
+    {
+    	return new CampaignConversionGoal();
+    }
+
+    /**
+     * Gets the campaign conversion goal.
+     */
+    public CampaignConversionGoal getCampaignConversionGoal() {
+        return campaignConversionGoal;
+    }
+
+    /**
+     * Sets the campaign conversion goal.
+     */
+    public void setCampaignConversionGoal(CampaignConversionGoal goal) {
+        this.campaignConversionGoal = goal;
+    }
+
+}
+
+

--- a/src/main/java/com/microsoft/bingads/v13/bulk/entities/BulkFeed.java
+++ b/src/main/java/com/microsoft/bingads/v13/bulk/entities/BulkFeed.java
@@ -44,6 +44,8 @@ public class BulkFeed extends SingleRecordBulkEntity {
 	
 	private String subType;
 	
+	private String schedule;
+	
 	private List<FeedCustomAttribute> customAttributes;
 
     private static final List<BulkMapping<BulkFeed>> MAPPINGS;
@@ -150,6 +152,21 @@ public class BulkFeed extends SingleRecordBulkEntity {
                     }
                 }
         ));
+        
+        m.add(new SimpleBulkMapping<BulkFeed, String>(StringTable.Schedule,
+                new Function<BulkFeed, String>() {
+                    @Override
+                    public String apply(BulkFeed t) {
+                        return t.getSchedule();
+                    }
+                },
+                new BiConsumer<String, BulkFeed>() {
+                    @Override
+                    public void accept(String v, BulkFeed c) {
+                        c.setSchedule(v);
+                    }
+                }
+        ));
 
         MAPPINGS = Collections.unmodifiableList(m);
     }
@@ -216,7 +233,16 @@ public class BulkFeed extends SingleRecordBulkEntity {
     public void setCustomAttributes(List<FeedCustomAttribute> customAttributes) {
         this.customAttributes = customAttributes;
     }
+    
+    public String getSchedule()
+    {
+    	return schedule;
+    }
 
+    public void setSchedule(String schedule)
+    {
+    	this.schedule = schedule;
+    }
     @Override
     public void processMappingsFromRowValues(RowValues values) {
         MappingHelpers.<BulkFeed>convertToEntity(values, MAPPINGS, this);

--- a/src/main/java/com/microsoft/bingads/v13/bulk/entities/BulkKeywordAdCustomizerAttribute.java
+++ b/src/main/java/com/microsoft/bingads/v13/bulk/entities/BulkKeywordAdCustomizerAttribute.java
@@ -1,0 +1,31 @@
+package com.microsoft.bingads.v13.bulk.entities;
+
+import com.microsoft.bingads.v13.bulk.BulkFileReader;
+import com.microsoft.bingads.v13.bulk.BulkFileWriter;
+import com.microsoft.bingads.v13.bulk.BulkOperation;
+import com.microsoft.bingads.v13.bulk.BulkServiceManager;
+
+/**
+ * Represents a Keyword Ad Customizer Attribute that can be read or written in a bulk file.
+ * <p/>
+ * <p>
+ * For more information, see Keyword Ad Customizer Attribute at
+ * <a href="https://go.microsoft.com/fwlink/?linkid=846127">https://go.microsoft.com/fwlink/?linkid=846127</a>.
+ * </p>
+ *
+ * @see BulkServiceManager
+ * @see BulkOperation
+ * @see BulkFileReader
+ * @see BulkFileWriter
+ */
+public class BulkKeywordAdCustomizerAttribute extends BulkAdCustomizerAttributeEntityBase {
+
+	public long getKeywordId() {
+		return parentId;
+	}
+	
+	public void setKeywordId(long keywordId) {
+		this.parentId = keywordId;
+	}
+
+}

--- a/src/main/java/com/microsoft/bingads/v13/bulk/entities/EditorialStatus.java
+++ b/src/main/java/com/microsoft/bingads/v13/bulk/entities/EditorialStatus.java
@@ -1,0 +1,30 @@
+package com.microsoft.bingads.v13.bulk.entities;
+
+/**
+ * Provides possible editorial status for bulk Ad Customizer Attributes.
+ */
+public enum EditorialStatus {
+	APPROVED("Approved"),
+	APPROVEDLIMITED("ApprovedLimited"),
+	REJECTED("Rejected"),
+	PENDING("Pending");
+	
+	private final String value;
+
+	EditorialStatus(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    public static EditorialStatus fromValue(String v) {
+        for (EditorialStatus c : EditorialStatus.values()) {
+            if (c.value.equals(v)) {
+                return c;
+            }
+        }
+        throw new IllegalArgumentException(v);
+    }
+}

--- a/src/main/java/com/microsoft/bingads/v13/bulk/entities/StaticBulkObjectFactory.java
+++ b/src/main/java/com/microsoft/bingads/v13/bulk/entities/StaticBulkObjectFactory.java
@@ -1022,6 +1022,38 @@ public class StaticBulkObjectFactory implements BulkObjectFactory {
             }
         }));
         
+        m.put(StringTable.AdCustomizerAttribute, new EntityInfo(new Creator<SingleRecordBulkEntity>() {
+            @Override
+            public SingleRecordBulkEntity create() {
+                return new BulkAdCustomizerAttribute();
+            }
+        }));
+        m.put(StringTable.AdcustomizerCampaign, new EntityInfo(new Creator<SingleRecordBulkEntity>() {
+            @Override
+            public SingleRecordBulkEntity create() {
+                return new BulkCampaignAdCustomizerAttribute();
+            }
+        }));
+        m.put(StringTable.AdcustomizerAdGroup, new EntityInfo(new Creator<SingleRecordBulkEntity>() {
+            @Override
+            public SingleRecordBulkEntity create() {
+                return new BulkAdGroupAdCustomizerAttribute();
+            }
+        }));
+        m.put(StringTable.AdcustomizerKeyword, new EntityInfo(new Creator<SingleRecordBulkEntity>() {
+            @Override
+            public SingleRecordBulkEntity create() {
+                return new BulkKeywordAdCustomizerAttribute();
+            }
+        }));
+
+        m.put(StringTable.CampaignConversionGoal, new EntityInfo(new Creator<SingleRecordBulkEntity>() {
+            @Override
+            public SingleRecordBulkEntity create() {
+                return new BulkCampaignConversionGoal();
+            }
+        }));
+        
         
         INDIVIDUAL_ENTITY_MAP = Collections.unmodifiableMap(m);
 

--- a/src/main/java/com/microsoft/bingads/v13/bulk/entities/WebpageConditionHelper.java
+++ b/src/main/java/com/microsoft/bingads/v13/bulk/entities/WebpageConditionHelper.java
@@ -16,9 +16,15 @@ class WebpageConditionHelper {
     public static void addRowValuesFromConditions(ArrayOfWebpageCondition arrayOfWebpageCondition, RowValues rowValues) {
         List<WebpageCondition> conditions = arrayOfWebpageCondition.getWebpageConditions();
         for (int i = 1; i <= conditions.size(); i++) {
-            rowValues.put(StringTable.DynamicAdTargetConditionColumnPrefix + i, conditions.get(i - 1).getOperand().value());
             rowValues.put(StringTable.DynamicAdTargetValueColumnPrefix + i, conditions.get(i - 1).getArgument());
-            rowValues.put(StringTable.DynamicAdTargetConditionOperatorPrefix + i, conditions.get(i - 1).getOperator().value());
+            if (conditions.get(i - 1).getOperand() != null)
+            {
+			    rowValues.put(StringTable.DynamicAdTargetConditionColumnPrefix + i, conditions.get(i - 1).getOperand().value());
+			}
+            if (conditions.get(i - 1).getOperator() != null)
+            {
+                rowValues.put(StringTable.DynamicAdTargetConditionOperatorPrefix + i, conditions.get(i - 1).getOperator().value());
+            }
         }
     }
 

--- a/src/main/java/com/microsoft/bingads/v13/internal/bulk/CsvHeaders.java
+++ b/src/main/java/com/microsoft/bingads/v13/internal/bulk/CsvHeaders.java
@@ -437,6 +437,14 @@ public class CsvHeaders {
             StringTable.PhysicalIntent,
             StringTable.TargetAdGroupId,
             StringTable.TargetCampaignId,
+            StringTable.Schedule,
+            
+            // Campaign Conversion Goal
+            StringTable.GoalId,
+            
+            //RSA AdCustomizer
+            StringTable.AdCustomizerDataType,
+            StringTable.AdCustomizerAttributeValue,
     };
 
     private static final Map<String, Integer> columnIndexMap = initializeMap();

--- a/src/main/java/com/microsoft/bingads/v13/internal/bulk/StringTable.java
+++ b/src/main/java/com/microsoft/bingads/v13/internal/bulk/StringTable.java
@@ -97,6 +97,7 @@ public class StringTable {
     public static final String CustomAttributes = "Custom Attributes";
     public static final String TargetAdGroupId = "Target Ad Group Id";
     public static final String TargetCampaignId = "Target Campaign Id";
+    public static final String Schedule = "Schedule";
     
     public static final String PhysicalIntent = "Physical Intent";
 
@@ -690,6 +691,18 @@ public class StringTable {
     public static final String AllowImageAutoRetrieve = "Allow Image Auto Retrieve";
     public static final String BusinessAttributes = "Business Attributes";
 
+    
+    //AdCustomizerAttribute
+    public static final String AdCustomizerAttribute = "Adcustomizer Attribute";
+    public static final String AdcustomizerCampaign = "Campaign Adcustomizer Attribute";
+    public static final String AdcustomizerAdGroup = "Adgroup Adcustomizer Attribute";
+    public static final String AdcustomizerKeyword = "Keyword Adcustomizer Attribute";
+    public static final String AdCustomizerDataType = "AdCustomizer DataType";
+    public static final String AdCustomizerAttributeValue = "AdCustomizer AttributeValue";
+    
+    // Campaign Conversion Goal
+    public static final String CampaignConversionGoal = "Campaign Conversion Goal";
+    public static final String GoalId = "Goal Id";
     
     static {
         Map<String, String> m = new HashMap<String, String>();

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/BulkAdCustomizerAttributeTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/BulkAdCustomizerAttributeTest.java
@@ -1,0 +1,122 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute;
+
+import java.util.Map;
+
+import com.microsoft.bingads.internal.functionalinterfaces.BiConsumer;
+import com.microsoft.bingads.internal.functionalinterfaces.Function;
+import com.microsoft.bingads.internal.functionalinterfaces.Supplier;
+import com.microsoft.bingads.v13.api.test.entities.BulkEntityTest;
+import com.microsoft.bingads.v13.api.test.entities.EqualityComparerWithDescription;
+import com.microsoft.bingads.v13.bulk.entities.BulkAdCustomizerAttribute;
+
+public abstract class BulkAdCustomizerAttributeTest extends BulkEntityTest<BulkAdCustomizerAttribute> {
+
+    @Override
+    protected void onEntityCreation(BulkAdCustomizerAttribute entity) {
+    	entity.setId("123");
+    }
+
+    @Override
+    protected <TProperty> void testWriteProperty(
+            String header,
+            String expectedRowValue,
+            TProperty propertyValue,
+            BiConsumer<BulkAdCustomizerAttribute, TProperty> setFunc
+    ) {
+        testWriteProperty(
+                header,
+                expectedRowValue,
+                propertyValue,
+                setFunc,
+                new Supplier<BulkAdCustomizerAttribute>() {
+                    @Override
+                    public BulkAdCustomizerAttribute get() {
+                        return new BulkAdCustomizerAttribute();
+                    }
+                }
+        );
+    }
+
+    @Override
+    protected <TProperty> void testReadProperty(
+            String header,
+            String input,
+            TProperty expectedResult,
+            Function<BulkAdCustomizerAttribute, TProperty> actualValueFunc
+    ) {
+        testReadProperty(
+                header,
+                input,
+                expectedResult,
+                actualValueFunc,
+                new Supplier<BulkAdCustomizerAttribute>() {
+                    @Override
+                    public BulkAdCustomizerAttribute get() {
+                        return new BulkAdCustomizerAttribute();
+                    }
+                }
+        );
+    }
+
+    @Override
+    protected <TProperty> void testReadProperty(
+            Map<String, String> rowValues,
+            TProperty expectedResult,
+            Function<BulkAdCustomizerAttribute, TProperty> actualValueFunc
+    ) {
+        testReadProperty(
+                rowValues,
+                expectedResult,
+                actualValueFunc,
+                new Supplier<BulkAdCustomizerAttribute>() {
+                    @Override
+                    public BulkAdCustomizerAttribute get() {
+                        return new BulkAdCustomizerAttribute();
+                    }
+                }
+        );
+    }
+
+    protected <TProperty> void testReadProperty(
+            String header,
+            String input,
+            TProperty expectedResult,
+            Function<BulkAdCustomizerAttribute, TProperty> actualValueFunc,
+            EqualityComparerWithDescription<TProperty> comparer
+    ) {
+        testReadProperty(
+                header,
+                input,
+                expectedResult,
+                actualValueFunc,
+                new Supplier<BulkAdCustomizerAttribute>() {
+                    @Override
+                    public BulkAdCustomizerAttribute get() {
+                        return new BulkAdCustomizerAttribute();
+                    }
+                },
+                comparer
+        );
+    }
+
+    protected <TProperty> void testReadProperty(
+            Map<String, String> rowValues,
+            TProperty expectedResult,
+            Function<BulkAdCustomizerAttribute, TProperty> actualValueFunc,
+            EqualityComparerWithDescription<TProperty> comparer
+    ) {
+        testReadProperty(
+                rowValues,
+                expectedResult,
+                actualValueFunc,
+                new Supplier<BulkAdCustomizerAttribute>() {
+                    @Override
+                    public BulkAdCustomizerAttribute get() {
+                        return new BulkAdCustomizerAttribute();
+                    }
+                },
+                comparer
+        );
+    }
+	
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/BulkAdCustomizerAttributeTests.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/BulkAdCustomizerAttributeTests.java
@@ -1,0 +1,17 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.read.BulkAdCustomizerAttributeReadTest;
+import com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.write.BulkAdCustomizerAttributeWriteTest;
+
+import junit.framework.TestCase;
+
+@RunWith(Suite.class)
+@SuiteClasses({BulkAdCustomizerAttributeReadTest.class, BulkAdCustomizerAttributeWriteTest.class})
+
+public class BulkAdCustomizerAttributeTests extends TestCase {
+
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/adgroup/BulkAdGroupAdCustomizerAttributeTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/adgroup/BulkAdGroupAdCustomizerAttributeTest.java
@@ -1,0 +1,122 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.adgroup;
+
+import java.util.Map;
+
+import com.microsoft.bingads.internal.functionalinterfaces.BiConsumer;
+import com.microsoft.bingads.internal.functionalinterfaces.Function;
+import com.microsoft.bingads.internal.functionalinterfaces.Supplier;
+import com.microsoft.bingads.v13.api.test.entities.BulkEntityTest;
+import com.microsoft.bingads.v13.api.test.entities.EqualityComparerWithDescription;
+import com.microsoft.bingads.v13.bulk.entities.BulkAdGroupAdCustomizerAttribute;
+
+public abstract class BulkAdGroupAdCustomizerAttributeTest extends BulkEntityTest<BulkAdGroupAdCustomizerAttribute> {
+
+    @Override
+    protected void onEntityCreation(BulkAdGroupAdCustomizerAttribute entity) {
+    	entity.setId("123");
+    }
+
+    @Override
+    protected <TProperty> void testWriteProperty(
+            String header,
+            String expectedRowValue,
+            TProperty propertyValue,
+            BiConsumer<BulkAdGroupAdCustomizerAttribute, TProperty> setFunc
+    ) {
+        testWriteProperty(
+                header,
+                expectedRowValue,
+                propertyValue,
+                setFunc,
+                new Supplier<BulkAdGroupAdCustomizerAttribute>() {
+                    @Override
+                    public BulkAdGroupAdCustomizerAttribute get() {
+                        return new BulkAdGroupAdCustomizerAttribute();
+                    }
+                }
+        );
+    }
+
+    @Override
+    protected <TProperty> void testReadProperty(
+            String header,
+            String input,
+            TProperty expectedResult,
+            Function<BulkAdGroupAdCustomizerAttribute, TProperty> actualValueFunc
+    ) {
+        testReadProperty(
+                header,
+                input,
+                expectedResult,
+                actualValueFunc,
+                new Supplier<BulkAdGroupAdCustomizerAttribute>() {
+                    @Override
+                    public BulkAdGroupAdCustomizerAttribute get() {
+                        return new BulkAdGroupAdCustomizerAttribute();
+                    }
+                }
+        );
+    }
+
+    @Override
+    protected <TProperty> void testReadProperty(
+            Map<String, String> rowValues,
+            TProperty expectedResult,
+            Function<BulkAdGroupAdCustomizerAttribute, TProperty> actualValueFunc
+    ) {
+        testReadProperty(
+                rowValues,
+                expectedResult,
+                actualValueFunc,
+                new Supplier<BulkAdGroupAdCustomizerAttribute>() {
+                    @Override
+                    public BulkAdGroupAdCustomizerAttribute get() {
+                        return new BulkAdGroupAdCustomizerAttribute();
+                    }
+                }
+        );
+    }
+
+    protected <TProperty> void testReadProperty(
+            String header,
+            String input,
+            TProperty expectedResult,
+            Function<BulkAdGroupAdCustomizerAttribute, TProperty> actualValueFunc,
+            EqualityComparerWithDescription<TProperty> comparer
+    ) {
+        testReadProperty(
+                header,
+                input,
+                expectedResult,
+                actualValueFunc,
+                new Supplier<BulkAdGroupAdCustomizerAttribute>() {
+                    @Override
+                    public BulkAdGroupAdCustomizerAttribute get() {
+                        return new BulkAdGroupAdCustomizerAttribute();
+                    }
+                },
+                comparer
+        );
+    }
+
+    protected <TProperty> void testReadProperty(
+            Map<String, String> rowValues,
+            TProperty expectedResult,
+            Function<BulkAdGroupAdCustomizerAttribute, TProperty> actualValueFunc,
+            EqualityComparerWithDescription<TProperty> comparer
+    ) {
+        testReadProperty(
+                rowValues,
+                expectedResult,
+                actualValueFunc,
+                new Supplier<BulkAdGroupAdCustomizerAttribute>() {
+                    @Override
+                    public BulkAdGroupAdCustomizerAttribute get() {
+                        return new BulkAdGroupAdCustomizerAttribute();
+                    }
+                },
+                comparer
+        );
+    }
+	
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/adgroup/BulkAdGroupAdCustomizerAttributeTests.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/adgroup/BulkAdGroupAdCustomizerAttributeTests.java
@@ -1,0 +1,17 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.adgroup;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.adgroup.read.BulkAdGroupAdCustomizerAttributeReadTest;
+import com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.adgroup.write.BulkAdGroupAdCustomizerAttributeWriteTest;
+
+import junit.framework.TestCase;
+
+@RunWith(Suite.class)
+@SuiteClasses({BulkAdGroupAdCustomizerAttributeReadTest.class, BulkAdGroupAdCustomizerAttributeWriteTest.class})
+
+public class BulkAdGroupAdCustomizerAttributeTests extends TestCase {
+
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/adgroup/read/BulkAdGroupAdCustomizerAttributeReadFromRowValuesAttributeValueTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/adgroup/read/BulkAdGroupAdCustomizerAttributeReadFromRowValuesAttributeValueTest.java
@@ -1,0 +1,39 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.adgroup.read;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.microsoft.bingads.internal.functionalinterfaces.Function;
+import com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.adgroup.BulkAdGroupAdCustomizerAttributeTest;
+import com.microsoft.bingads.v13.bulk.entities.BulkAdGroupAdCustomizerAttribute;
+import com.microsoft.bingads.v13.internal.bulk.StringTable;
+
+public class BulkAdGroupAdCustomizerAttributeReadFromRowValuesAttributeValueTest
+		extends BulkAdGroupAdCustomizerAttributeTest {
+
+	@Parameter(value = 1)
+    public String expectedResult;
+	
+	@Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"Test Attribute Value", "Test Attribute Value"},
+            {"", ""},
+            {null, null},});
+    }
+    
+    @Test
+    public void testRead() {
+        this.<String>testReadProperty(StringTable.AdCustomizerAttributeValue, this.datum, this.expectedResult, new Function<BulkAdGroupAdCustomizerAttribute, String>() {
+            @Override
+            public String apply(BulkAdGroupAdCustomizerAttribute c) {
+                return c.getAttributeValue();
+            }
+        });
+    }
+	
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/adgroup/read/BulkAdGroupAdCustomizerAttributeReadFromRowValuesEditorialStatusTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/adgroup/read/BulkAdGroupAdCustomizerAttributeReadFromRowValuesEditorialStatusTest.java
@@ -1,0 +1,42 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.adgroup.read;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.microsoft.bingads.internal.functionalinterfaces.Function;
+import com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.adgroup.BulkAdGroupAdCustomizerAttributeTest;
+import com.microsoft.bingads.v13.bulk.entities.BulkAdGroupAdCustomizerAttribute;
+import com.microsoft.bingads.v13.bulk.entities.EditorialStatus;
+import com.microsoft.bingads.v13.internal.bulk.StringTable;
+
+public class BulkAdGroupAdCustomizerAttributeReadFromRowValuesEditorialStatusTest
+		extends BulkAdGroupAdCustomizerAttributeTest {
+	
+	@Parameter(value = 1)
+    public EditorialStatus expectedResult;
+	
+	@Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"Approved", EditorialStatus.APPROVED},
+            {"ApprovedLimited", EditorialStatus.APPROVEDLIMITED},
+            {"Pending", EditorialStatus.PENDING},
+            {"Rejected", EditorialStatus.REJECTED},
+            {"", null},
+            {null, null},});
+    }
+    
+    @Test
+    public void testRead() {
+        this.<EditorialStatus>testReadProperty(StringTable.EditorialStatus, this.datum, this.expectedResult, new Function<BulkAdGroupAdCustomizerAttribute, EditorialStatus>() {
+            @Override
+            public EditorialStatus apply(BulkAdGroupAdCustomizerAttribute c) {
+                return c.getEditorialStatus();
+            }
+        });
+    }
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/adgroup/read/BulkAdGroupAdCustomizerAttributeReadFromRowValuesIdTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/adgroup/read/BulkAdGroupAdCustomizerAttributeReadFromRowValuesIdTest.java
@@ -1,0 +1,36 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.adgroup.read;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.microsoft.bingads.internal.functionalinterfaces.Function;
+import com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.adgroup.BulkAdGroupAdCustomizerAttributeTest;
+import com.microsoft.bingads.v13.bulk.entities.BulkAdGroupAdCustomizerAttribute;
+
+public class BulkAdGroupAdCustomizerAttributeReadFromRowValuesIdTest extends BulkAdGroupAdCustomizerAttributeTest {
+
+	@Parameter(value = 1)
+    public String expectedResult;
+	
+	@Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"12345678", "12345678"},
+            {"", ""},
+            {null, null},});
+    }
+    
+    @Test
+    public void testRead() {
+        this.<String>testReadProperty("Id", this.datum, this.expectedResult, new Function<BulkAdGroupAdCustomizerAttribute, String>() {
+            @Override
+            public String apply(BulkAdGroupAdCustomizerAttribute c) {
+                return c.getId();
+            }
+        });
+    }
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/adgroup/read/BulkAdGroupAdCustomizerAttributeReadFromRowValuesNameTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/adgroup/read/BulkAdGroupAdCustomizerAttributeReadFromRowValuesNameTest.java
@@ -1,0 +1,37 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.adgroup.read;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.microsoft.bingads.internal.functionalinterfaces.Function;
+import com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.adgroup.BulkAdGroupAdCustomizerAttributeTest;
+import com.microsoft.bingads.v13.bulk.entities.BulkAdGroupAdCustomizerAttribute;
+
+public class BulkAdGroupAdCustomizerAttributeReadFromRowValuesNameTest extends BulkAdGroupAdCustomizerAttributeTest {
+
+	@Parameter(value = 1)
+    public String expectedResult;
+	
+	@Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"Test Name", "Test Name"},
+            {"", ""},
+            {null, null},});
+    }
+    
+    @Test
+    public void testRead() {
+        this.<String>testReadProperty("Name", this.datum, this.expectedResult, new Function<BulkAdGroupAdCustomizerAttribute, String>() {
+            @Override
+            public String apply(BulkAdGroupAdCustomizerAttribute c) {
+                return c.getName();
+            }
+        });
+    }
+	
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/adgroup/read/BulkAdGroupAdCustomizerAttributeReadFromRowValuesParentIdTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/adgroup/read/BulkAdGroupAdCustomizerAttributeReadFromRowValuesParentIdTest.java
@@ -1,0 +1,36 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.adgroup.read;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.microsoft.bingads.internal.functionalinterfaces.Function;
+import com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.adgroup.BulkAdGroupAdCustomizerAttributeTest;
+import com.microsoft.bingads.v13.bulk.entities.BulkAdGroupAdCustomizerAttribute;
+
+public class BulkAdGroupAdCustomizerAttributeReadFromRowValuesParentIdTest
+		extends BulkAdGroupAdCustomizerAttributeTest {
+	
+	@Parameter(value = 1)
+    public Long expectedResult;
+	
+	@Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"123", 123L},
+            {"12345678", 12345678L},});
+    }
+    
+    @Test
+    public void testRead() {
+        this.<Long>testReadProperty("Parent Id", this.datum, this.expectedResult, new Function<BulkAdGroupAdCustomizerAttribute, Long>() {
+            @Override
+            public Long apply(BulkAdGroupAdCustomizerAttribute c) {
+                return c.getParentId();
+            }
+        });
+    }
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/adgroup/read/BulkAdGroupAdCustomizerAttributeReadTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/adgroup/read/BulkAdGroupAdCustomizerAttributeReadTest.java
@@ -1,0 +1,18 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.adgroup.read;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+@RunWith(Suite.class)
+@SuiteClasses({
+	BulkAdGroupAdCustomizerAttributeReadFromRowValuesParentIdTest.class,
+	BulkAdGroupAdCustomizerAttributeReadFromRowValuesNameTest.class,
+	BulkAdGroupAdCustomizerAttributeReadFromRowValuesIdTest.class,
+	BulkAdGroupAdCustomizerAttributeReadFromRowValuesEditorialStatusTest.class,
+	BulkAdGroupAdCustomizerAttributeReadFromRowValuesAttributeValueTest.class
+})
+
+public class BulkAdGroupAdCustomizerAttributeReadTest {
+
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/adgroup/write/BulkAdGroupAdCustomizerAttributeWriteTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/adgroup/write/BulkAdGroupAdCustomizerAttributeWriteTest.java
@@ -1,0 +1,16 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.adgroup.write;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+@RunWith(Suite.class)
+@SuiteClasses({
+	BulkAdGroupAdCustomizerAttributeWriteToRowValuesAttributeValueTest.class,
+	BulkAdGroupAdCustomizerAttributeWriteToRowValuesIdTest.class,
+	BulkAdGroupAdCustomizerAttributeWriteToRowValuesNameTest.class
+})
+
+public class BulkAdGroupAdCustomizerAttributeWriteTest {
+
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/adgroup/write/BulkAdGroupAdCustomizerAttributeWriteToRowValuesAttributeValueTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/adgroup/write/BulkAdGroupAdCustomizerAttributeWriteToRowValuesAttributeValueTest.java
@@ -1,0 +1,39 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.adgroup.write;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.microsoft.bingads.internal.functionalinterfaces.BiConsumer;
+import com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.adgroup.BulkAdGroupAdCustomizerAttributeTest;
+import com.microsoft.bingads.v13.bulk.entities.BulkAdGroupAdCustomizerAttribute;
+import com.microsoft.bingads.v13.internal.bulk.StringTable;
+
+public class BulkAdGroupAdCustomizerAttributeWriteToRowValuesAttributeValueTest
+		extends BulkAdGroupAdCustomizerAttributeTest {
+
+	@Parameter(value = 1)
+    public String propertyValue;
+	
+	@Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"Test Attribute Value", "Test Attribute Value"},
+            {"", ""},
+            {null, null},});
+    }
+    
+    @Test
+    public void testWrite() {
+        this.<String>testWriteProperty(StringTable.AdCustomizerAttributeValue, this.datum, this.propertyValue, new BiConsumer<BulkAdGroupAdCustomizerAttribute, String>() {
+            @Override
+            public void accept(BulkAdGroupAdCustomizerAttribute c, String v) {
+                c.setAttributeValue(v);
+            }
+        });
+    }
+    
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/adgroup/write/BulkAdGroupAdCustomizerAttributeWriteToRowValuesIdTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/adgroup/write/BulkAdGroupAdCustomizerAttributeWriteToRowValuesIdTest.java
@@ -1,0 +1,36 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.adgroup.write;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.microsoft.bingads.internal.functionalinterfaces.BiConsumer;
+import com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.adgroup.BulkAdGroupAdCustomizerAttributeTest;
+import com.microsoft.bingads.v13.bulk.entities.BulkAdGroupAdCustomizerAttribute;
+
+public class BulkAdGroupAdCustomizerAttributeWriteToRowValuesIdTest extends BulkAdGroupAdCustomizerAttributeTest {
+	
+	@Parameter(value = 1)
+    public String propertyValue;
+	
+	@Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"12345678", "12345678"},
+            {"", ""},
+            {null, null},});
+    }
+    
+    @Test
+    public void testWrite() {
+        this.<String>testWriteProperty("Id", this.datum, this.propertyValue, new BiConsumer<BulkAdGroupAdCustomizerAttribute, String>() {
+            @Override
+            public void accept(BulkAdGroupAdCustomizerAttribute c, String v) {
+                c.setId(v);
+            }
+        });
+    }
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/adgroup/write/BulkAdGroupAdCustomizerAttributeWriteToRowValuesNameTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/adgroup/write/BulkAdGroupAdCustomizerAttributeWriteToRowValuesNameTest.java
@@ -1,0 +1,40 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.adgroup.write;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.microsoft.bingads.internal.functionalinterfaces.BiConsumer;
+import com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.adgroup.BulkAdGroupAdCustomizerAttributeTest;
+import com.microsoft.bingads.v13.bulk.entities.BulkAdGroupAdCustomizerAttribute;
+
+@RunWith(Parameterized.class)
+public class BulkAdGroupAdCustomizerAttributeWriteToRowValuesNameTest extends BulkAdGroupAdCustomizerAttributeTest {
+	
+	@Parameter(value = 1)
+    public String propertyValue;
+	
+	@Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"Test Name", "Test Name"},
+            {"", ""},
+            {null, null},});
+    }
+    
+    @Test
+    public void testWrite() {
+        this.<String>testWriteProperty("Name", this.datum, this.propertyValue, new BiConsumer<BulkAdGroupAdCustomizerAttribute, String>() {
+            @Override
+            public void accept(BulkAdGroupAdCustomizerAttribute c, String v) {
+                c.setName(v);
+            }
+        });
+    }
+	
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/campaign/BulkCampaignAdCustomizerAttributeTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/campaign/BulkCampaignAdCustomizerAttributeTest.java
@@ -1,0 +1,122 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.campaign;
+
+import java.util.Map;
+
+import com.microsoft.bingads.internal.functionalinterfaces.BiConsumer;
+import com.microsoft.bingads.internal.functionalinterfaces.Function;
+import com.microsoft.bingads.internal.functionalinterfaces.Supplier;
+import com.microsoft.bingads.v13.api.test.entities.BulkEntityTest;
+import com.microsoft.bingads.v13.api.test.entities.EqualityComparerWithDescription;
+import com.microsoft.bingads.v13.bulk.entities.BulkCampaignAdCustomizerAttribute;
+
+public abstract class BulkCampaignAdCustomizerAttributeTest extends BulkEntityTest<BulkCampaignAdCustomizerAttribute> {
+
+    @Override
+    protected void onEntityCreation(BulkCampaignAdCustomizerAttribute entity) {
+    	entity.setId("123");
+    }
+
+    @Override
+    protected <TProperty> void testWriteProperty(
+            String header,
+            String expectedRowValue,
+            TProperty propertyValue,
+            BiConsumer<BulkCampaignAdCustomizerAttribute, TProperty> setFunc
+    ) {
+        testWriteProperty(
+                header,
+                expectedRowValue,
+                propertyValue,
+                setFunc,
+                new Supplier<BulkCampaignAdCustomizerAttribute>() {
+                    @Override
+                    public BulkCampaignAdCustomizerAttribute get() {
+                        return new BulkCampaignAdCustomizerAttribute();
+                    }
+                }
+        );
+    }
+
+    @Override
+    protected <TProperty> void testReadProperty(
+            String header,
+            String input,
+            TProperty expectedResult,
+            Function<BulkCampaignAdCustomizerAttribute, TProperty> actualValueFunc
+    ) {
+        testReadProperty(
+                header,
+                input,
+                expectedResult,
+                actualValueFunc,
+                new Supplier<BulkCampaignAdCustomizerAttribute>() {
+                    @Override
+                    public BulkCampaignAdCustomizerAttribute get() {
+                        return new BulkCampaignAdCustomizerAttribute();
+                    }
+                }
+        );
+    }
+
+    @Override
+    protected <TProperty> void testReadProperty(
+            Map<String, String> rowValues,
+            TProperty expectedResult,
+            Function<BulkCampaignAdCustomizerAttribute, TProperty> actualValueFunc
+    ) {
+        testReadProperty(
+                rowValues,
+                expectedResult,
+                actualValueFunc,
+                new Supplier<BulkCampaignAdCustomizerAttribute>() {
+                    @Override
+                    public BulkCampaignAdCustomizerAttribute get() {
+                        return new BulkCampaignAdCustomizerAttribute();
+                    }
+                }
+        );
+    }
+
+    protected <TProperty> void testReadProperty(
+            String header,
+            String input,
+            TProperty expectedResult,
+            Function<BulkCampaignAdCustomizerAttribute, TProperty> actualValueFunc,
+            EqualityComparerWithDescription<TProperty> comparer
+    ) {
+        testReadProperty(
+                header,
+                input,
+                expectedResult,
+                actualValueFunc,
+                new Supplier<BulkCampaignAdCustomizerAttribute>() {
+                    @Override
+                    public BulkCampaignAdCustomizerAttribute get() {
+                        return new BulkCampaignAdCustomizerAttribute();
+                    }
+                },
+                comparer
+        );
+    }
+
+    protected <TProperty> void testReadProperty(
+            Map<String, String> rowValues,
+            TProperty expectedResult,
+            Function<BulkCampaignAdCustomizerAttribute, TProperty> actualValueFunc,
+            EqualityComparerWithDescription<TProperty> comparer
+    ) {
+        testReadProperty(
+                rowValues,
+                expectedResult,
+                actualValueFunc,
+                new Supplier<BulkCampaignAdCustomizerAttribute>() {
+                    @Override
+                    public BulkCampaignAdCustomizerAttribute get() {
+                        return new BulkCampaignAdCustomizerAttribute();
+                    }
+                },
+                comparer
+        );
+    }
+	
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/campaign/BulkCampaignAdCustomizerAttributeTests.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/campaign/BulkCampaignAdCustomizerAttributeTests.java
@@ -1,0 +1,17 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.campaign;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.campaign.read.BulkCampaignAdCustomizerAttributeReadTest;
+import com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.campaign.write.BulkCampaignAdCustomizerAttributeWriteTest;
+
+import junit.framework.TestCase;
+
+@RunWith(Suite.class)
+@SuiteClasses({BulkCampaignAdCustomizerAttributeReadTest.class, BulkCampaignAdCustomizerAttributeWriteTest.class})
+
+public class BulkCampaignAdCustomizerAttributeTests extends TestCase {
+
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/campaign/read/BulkCampaignAdCustomizerAttributeReadFromRowValuesAttributeValueTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/campaign/read/BulkCampaignAdCustomizerAttributeReadFromRowValuesAttributeValueTest.java
@@ -1,0 +1,39 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.campaign.read;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.microsoft.bingads.internal.functionalinterfaces.Function;
+import com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.campaign.BulkCampaignAdCustomizerAttributeTest;
+import com.microsoft.bingads.v13.bulk.entities.BulkCampaignAdCustomizerAttribute;
+import com.microsoft.bingads.v13.internal.bulk.StringTable;
+
+public class BulkCampaignAdCustomizerAttributeReadFromRowValuesAttributeValueTest
+		extends BulkCampaignAdCustomizerAttributeTest {
+
+	@Parameter(value = 1)
+    public String expectedResult;
+	
+	@Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"Test Attribute Value", "Test Attribute Value"},
+            {"", ""},
+            {null, null},});
+    }
+    
+    @Test
+    public void testRead() {
+        this.<String>testReadProperty(StringTable.AdCustomizerAttributeValue, this.datum, this.expectedResult, new Function<BulkCampaignAdCustomizerAttribute, String>() {
+            @Override
+            public String apply(BulkCampaignAdCustomizerAttribute c) {
+                return c.getAttributeValue();
+            }
+        });
+    }
+	
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/campaign/read/BulkCampaignAdCustomizerAttributeReadFromRowValuesEditorialStatusTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/campaign/read/BulkCampaignAdCustomizerAttributeReadFromRowValuesEditorialStatusTest.java
@@ -1,0 +1,42 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.campaign.read;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.microsoft.bingads.internal.functionalinterfaces.Function;
+import com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.campaign.BulkCampaignAdCustomizerAttributeTest;
+import com.microsoft.bingads.v13.bulk.entities.BulkCampaignAdCustomizerAttribute;
+import com.microsoft.bingads.v13.bulk.entities.EditorialStatus;
+import com.microsoft.bingads.v13.internal.bulk.StringTable;
+
+public class BulkCampaignAdCustomizerAttributeReadFromRowValuesEditorialStatusTest
+		extends BulkCampaignAdCustomizerAttributeTest {
+	
+	@Parameter(value = 1)
+    public EditorialStatus expectedResult;
+	
+	@Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"Approved", EditorialStatus.APPROVED},
+            {"ApprovedLimited", EditorialStatus.APPROVEDLIMITED},
+            {"Pending", EditorialStatus.PENDING},
+            {"Rejected", EditorialStatus.REJECTED},
+            {"", null},
+            {null, null},});
+    }
+    
+    @Test
+    public void testRead() {
+        this.<EditorialStatus>testReadProperty(StringTable.EditorialStatus, this.datum, this.expectedResult, new Function<BulkCampaignAdCustomizerAttribute, EditorialStatus>() {
+            @Override
+            public EditorialStatus apply(BulkCampaignAdCustomizerAttribute c) {
+                return c.getEditorialStatus();
+            }
+        });
+    }
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/campaign/read/BulkCampaignAdCustomizerAttributeReadFromRowValuesIdTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/campaign/read/BulkCampaignAdCustomizerAttributeReadFromRowValuesIdTest.java
@@ -1,0 +1,36 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.campaign.read;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.microsoft.bingads.internal.functionalinterfaces.Function;
+import com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.campaign.BulkCampaignAdCustomizerAttributeTest;
+import com.microsoft.bingads.v13.bulk.entities.BulkCampaignAdCustomizerAttribute;
+
+public class BulkCampaignAdCustomizerAttributeReadFromRowValuesIdTest extends BulkCampaignAdCustomizerAttributeTest {
+
+	@Parameter(value = 1)
+    public String expectedResult;
+	
+	@Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"12345678", "12345678"},
+            {"", ""},
+            {null, null},});
+    }
+    
+    @Test
+    public void testRead() {
+        this.<String>testReadProperty("Id", this.datum, this.expectedResult, new Function<BulkCampaignAdCustomizerAttribute, String>() {
+            @Override
+            public String apply(BulkCampaignAdCustomizerAttribute c) {
+                return c.getId();
+            }
+        });
+    }
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/campaign/read/BulkCampaignAdCustomizerAttributeReadFromRowValuesNameTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/campaign/read/BulkCampaignAdCustomizerAttributeReadFromRowValuesNameTest.java
@@ -1,0 +1,37 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.campaign.read;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.microsoft.bingads.internal.functionalinterfaces.Function;
+import com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.campaign.BulkCampaignAdCustomizerAttributeTest;
+import com.microsoft.bingads.v13.bulk.entities.BulkCampaignAdCustomizerAttribute;
+
+public class BulkCampaignAdCustomizerAttributeReadFromRowValuesNameTest extends BulkCampaignAdCustomizerAttributeTest {
+
+	@Parameter(value = 1)
+    public String expectedResult;
+	
+	@Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"Test Name", "Test Name"},
+            {"", ""},
+            {null, null},});
+    }
+    
+    @Test
+    public void testRead() {
+        this.<String>testReadProperty("Name", this.datum, this.expectedResult, new Function<BulkCampaignAdCustomizerAttribute, String>() {
+            @Override
+            public String apply(BulkCampaignAdCustomizerAttribute c) {
+                return c.getName();
+            }
+        });
+    }
+	
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/campaign/read/BulkCampaignAdCustomizerAttributeReadFromRowValuesParentIdTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/campaign/read/BulkCampaignAdCustomizerAttributeReadFromRowValuesParentIdTest.java
@@ -1,0 +1,36 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.campaign.read;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.microsoft.bingads.internal.functionalinterfaces.Function;
+import com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.campaign.BulkCampaignAdCustomizerAttributeTest;
+import com.microsoft.bingads.v13.bulk.entities.BulkCampaignAdCustomizerAttribute;
+
+public class BulkCampaignAdCustomizerAttributeReadFromRowValuesParentIdTest
+		extends BulkCampaignAdCustomizerAttributeTest {
+	
+	@Parameter(value = 1)
+    public Long expectedResult;
+	
+	@Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"123", 123L},
+            {"12345678", 12345678L},});
+    }
+    
+    @Test
+    public void testRead() {
+        this.<Long>testReadProperty("Parent Id", this.datum, this.expectedResult, new Function<BulkCampaignAdCustomizerAttribute, Long>() {
+            @Override
+            public Long apply(BulkCampaignAdCustomizerAttribute c) {
+                return c.getParentId();
+            }
+        });
+    }
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/campaign/read/BulkCampaignAdCustomizerAttributeReadTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/campaign/read/BulkCampaignAdCustomizerAttributeReadTest.java
@@ -1,0 +1,18 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.campaign.read;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+@RunWith(Suite.class)
+@SuiteClasses({
+	BulkCampaignAdCustomizerAttributeReadFromRowValuesParentIdTest.class,
+	BulkCampaignAdCustomizerAttributeReadFromRowValuesNameTest.class,
+	BulkCampaignAdCustomizerAttributeReadFromRowValuesIdTest.class,
+	BulkCampaignAdCustomizerAttributeReadFromRowValuesEditorialStatusTest.class,
+	BulkCampaignAdCustomizerAttributeReadFromRowValuesAttributeValueTest.class
+})
+
+public class BulkCampaignAdCustomizerAttributeReadTest {
+
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/campaign/write/BulkCampaignAdCustomizerAttributeWriteTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/campaign/write/BulkCampaignAdCustomizerAttributeWriteTest.java
@@ -1,0 +1,16 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.campaign.write;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+@RunWith(Suite.class)
+@SuiteClasses({
+	BulkCampaignAdCustomizerAttributeWriteToRowValuesNameTest.class,
+	BulkCampaignAdCustomizerAttributeWriteToRowValuesIdTest.class,
+	BulkCampaignAdCustomizerAttributeWriteToRowValuesAttributeValueTest.class
+})
+
+public class BulkCampaignAdCustomizerAttributeWriteTest {
+
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/campaign/write/BulkCampaignAdCustomizerAttributeWriteToRowValuesAttributeValueTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/campaign/write/BulkCampaignAdCustomizerAttributeWriteToRowValuesAttributeValueTest.java
@@ -1,0 +1,39 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.campaign.write;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.microsoft.bingads.internal.functionalinterfaces.BiConsumer;
+import com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.campaign.BulkCampaignAdCustomizerAttributeTest;
+import com.microsoft.bingads.v13.bulk.entities.BulkCampaignAdCustomizerAttribute;
+import com.microsoft.bingads.v13.internal.bulk.StringTable;
+
+public class BulkCampaignAdCustomizerAttributeWriteToRowValuesAttributeValueTest
+		extends BulkCampaignAdCustomizerAttributeTest {
+
+	@Parameter(value = 1)
+    public String propertyValue;
+	
+	@Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"Test Attribute Value", "Test Attribute Value"},
+            {"", ""},
+            {null, null},});
+    }
+    
+    @Test
+    public void testWrite() {
+        this.<String>testWriteProperty(StringTable.AdCustomizerAttributeValue, this.datum, this.propertyValue, new BiConsumer<BulkCampaignAdCustomizerAttribute, String>() {
+            @Override
+            public void accept(BulkCampaignAdCustomizerAttribute c, String v) {
+                c.setAttributeValue(v);
+            }
+        });
+    }
+    
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/campaign/write/BulkCampaignAdCustomizerAttributeWriteToRowValuesIdTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/campaign/write/BulkCampaignAdCustomizerAttributeWriteToRowValuesIdTest.java
@@ -1,0 +1,36 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.campaign.write;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.microsoft.bingads.internal.functionalinterfaces.BiConsumer;
+import com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.campaign.BulkCampaignAdCustomizerAttributeTest;
+import com.microsoft.bingads.v13.bulk.entities.BulkCampaignAdCustomizerAttribute;
+
+public class BulkCampaignAdCustomizerAttributeWriteToRowValuesIdTest extends BulkCampaignAdCustomizerAttributeTest {
+	
+	@Parameter(value = 1)
+    public String propertyValue;
+	
+	@Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"12345678", "12345678"},
+            {"", ""},
+            {null, null},});
+    }
+    
+    @Test
+    public void testWrite() {
+        this.<String>testWriteProperty("Id", this.datum, this.propertyValue, new BiConsumer<BulkCampaignAdCustomizerAttribute, String>() {
+            @Override
+            public void accept(BulkCampaignAdCustomizerAttribute c, String v) {
+                c.setId(v);
+            }
+        });
+    }
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/campaign/write/BulkCampaignAdCustomizerAttributeWriteToRowValuesNameTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/campaign/write/BulkCampaignAdCustomizerAttributeWriteToRowValuesNameTest.java
@@ -1,0 +1,40 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.campaign.write;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.microsoft.bingads.internal.functionalinterfaces.BiConsumer;
+import com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.campaign.BulkCampaignAdCustomizerAttributeTest;
+import com.microsoft.bingads.v13.bulk.entities.BulkCampaignAdCustomizerAttribute;
+
+@RunWith(Parameterized.class)
+public class BulkCampaignAdCustomizerAttributeWriteToRowValuesNameTest extends BulkCampaignAdCustomizerAttributeTest {
+	
+	@Parameter(value = 1)
+    public String propertyValue;
+	
+	@Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"Test Name", "Test Name"},
+            {"", ""},
+            {null, null},});
+    }
+    
+    @Test
+    public void testWrite() {
+        this.<String>testWriteProperty("Name", this.datum, this.propertyValue, new BiConsumer<BulkCampaignAdCustomizerAttribute, String>() {
+            @Override
+            public void accept(BulkCampaignAdCustomizerAttribute c, String v) {
+                c.setName(v);
+            }
+        });
+    }
+	
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/keyword/BulkKeywordAdCustomizerAttributeTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/keyword/BulkKeywordAdCustomizerAttributeTest.java
@@ -1,0 +1,122 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.keyword;
+
+import java.util.Map;
+
+import com.microsoft.bingads.internal.functionalinterfaces.BiConsumer;
+import com.microsoft.bingads.internal.functionalinterfaces.Function;
+import com.microsoft.bingads.internal.functionalinterfaces.Supplier;
+import com.microsoft.bingads.v13.api.test.entities.BulkEntityTest;
+import com.microsoft.bingads.v13.api.test.entities.EqualityComparerWithDescription;
+import com.microsoft.bingads.v13.bulk.entities.BulkKeywordAdCustomizerAttribute;
+
+public abstract class BulkKeywordAdCustomizerAttributeTest extends BulkEntityTest<BulkKeywordAdCustomizerAttribute> {
+
+    @Override
+    protected void onEntityCreation(BulkKeywordAdCustomizerAttribute entity) {
+    	entity.setId("123");
+    }
+
+    @Override
+    protected <TProperty> void testWriteProperty(
+            String header,
+            String expectedRowValue,
+            TProperty propertyValue,
+            BiConsumer<BulkKeywordAdCustomizerAttribute, TProperty> setFunc
+    ) {
+        testWriteProperty(
+                header,
+                expectedRowValue,
+                propertyValue,
+                setFunc,
+                new Supplier<BulkKeywordAdCustomizerAttribute>() {
+                    @Override
+                    public BulkKeywordAdCustomizerAttribute get() {
+                        return new BulkKeywordAdCustomizerAttribute();
+                    }
+                }
+        );
+    }
+
+    @Override
+    protected <TProperty> void testReadProperty(
+            String header,
+            String input,
+            TProperty expectedResult,
+            Function<BulkKeywordAdCustomizerAttribute, TProperty> actualValueFunc
+    ) {
+        testReadProperty(
+                header,
+                input,
+                expectedResult,
+                actualValueFunc,
+                new Supplier<BulkKeywordAdCustomizerAttribute>() {
+                    @Override
+                    public BulkKeywordAdCustomizerAttribute get() {
+                        return new BulkKeywordAdCustomizerAttribute();
+                    }
+                }
+        );
+    }
+
+    @Override
+    protected <TProperty> void testReadProperty(
+            Map<String, String> rowValues,
+            TProperty expectedResult,
+            Function<BulkKeywordAdCustomizerAttribute, TProperty> actualValueFunc
+    ) {
+        testReadProperty(
+                rowValues,
+                expectedResult,
+                actualValueFunc,
+                new Supplier<BulkKeywordAdCustomizerAttribute>() {
+                    @Override
+                    public BulkKeywordAdCustomizerAttribute get() {
+                        return new BulkKeywordAdCustomizerAttribute();
+                    }
+                }
+        );
+    }
+
+    protected <TProperty> void testReadProperty(
+            String header,
+            String input,
+            TProperty expectedResult,
+            Function<BulkKeywordAdCustomizerAttribute, TProperty> actualValueFunc,
+            EqualityComparerWithDescription<TProperty> comparer
+    ) {
+        testReadProperty(
+                header,
+                input,
+                expectedResult,
+                actualValueFunc,
+                new Supplier<BulkKeywordAdCustomizerAttribute>() {
+                    @Override
+                    public BulkKeywordAdCustomizerAttribute get() {
+                        return new BulkKeywordAdCustomizerAttribute();
+                    }
+                },
+                comparer
+        );
+    }
+
+    protected <TProperty> void testReadProperty(
+            Map<String, String> rowValues,
+            TProperty expectedResult,
+            Function<BulkKeywordAdCustomizerAttribute, TProperty> actualValueFunc,
+            EqualityComparerWithDescription<TProperty> comparer
+    ) {
+        testReadProperty(
+                rowValues,
+                expectedResult,
+                actualValueFunc,
+                new Supplier<BulkKeywordAdCustomizerAttribute>() {
+                    @Override
+                    public BulkKeywordAdCustomizerAttribute get() {
+                        return new BulkKeywordAdCustomizerAttribute();
+                    }
+                },
+                comparer
+        );
+    }
+	
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/keyword/BulkKeywordAdCustomizerAttributeTests.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/keyword/BulkKeywordAdCustomizerAttributeTests.java
@@ -1,0 +1,17 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.keyword;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.keyword.read.BulkKeywordAdCustomizerAttributeReadTest;
+import com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.keyword.write.BulkKeywordAdCustomizerAttributeWriteTest;
+
+import junit.framework.TestCase;
+
+@RunWith(Suite.class)
+@SuiteClasses({BulkKeywordAdCustomizerAttributeReadTest.class, BulkKeywordAdCustomizerAttributeWriteTest.class})
+
+public class BulkKeywordAdCustomizerAttributeTests extends TestCase {
+
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/keyword/read/BulkKeywordAdCustomizerAttributeReadFromRowValuesAttributeValueTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/keyword/read/BulkKeywordAdCustomizerAttributeReadFromRowValuesAttributeValueTest.java
@@ -1,0 +1,39 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.keyword.read;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.microsoft.bingads.internal.functionalinterfaces.Function;
+import com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.keyword.BulkKeywordAdCustomizerAttributeTest;
+import com.microsoft.bingads.v13.bulk.entities.BulkKeywordAdCustomizerAttribute;
+import com.microsoft.bingads.v13.internal.bulk.StringTable;
+
+public class BulkKeywordAdCustomizerAttributeReadFromRowValuesAttributeValueTest
+		extends BulkKeywordAdCustomizerAttributeTest {
+
+	@Parameter(value = 1)
+    public String expectedResult;
+	
+	@Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"Test Attribute Value", "Test Attribute Value"},
+            {"", ""},
+            {null, null},});
+    }
+    
+    @Test
+    public void testRead() {
+        this.<String>testReadProperty(StringTable.AdCustomizerAttributeValue, this.datum, this.expectedResult, new Function<BulkKeywordAdCustomizerAttribute, String>() {
+            @Override
+            public String apply(BulkKeywordAdCustomizerAttribute c) {
+                return c.getAttributeValue();
+            }
+        });
+    }
+	
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/keyword/read/BulkKeywordAdCustomizerAttributeReadFromRowValuesEditorialStatusTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/keyword/read/BulkKeywordAdCustomizerAttributeReadFromRowValuesEditorialStatusTest.java
@@ -1,0 +1,42 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.keyword.read;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.microsoft.bingads.internal.functionalinterfaces.Function;
+import com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.keyword.BulkKeywordAdCustomizerAttributeTest;
+import com.microsoft.bingads.v13.bulk.entities.BulkKeywordAdCustomizerAttribute;
+import com.microsoft.bingads.v13.bulk.entities.EditorialStatus;
+import com.microsoft.bingads.v13.internal.bulk.StringTable;
+
+public class BulkKeywordAdCustomizerAttributeReadFromRowValuesEditorialStatusTest
+		extends BulkKeywordAdCustomizerAttributeTest {
+	
+	@Parameter(value = 1)
+    public EditorialStatus expectedResult;
+	
+	@Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"Approved", EditorialStatus.APPROVED},
+            {"ApprovedLimited", EditorialStatus.APPROVEDLIMITED},
+            {"Pending", EditorialStatus.PENDING},
+            {"Rejected", EditorialStatus.REJECTED},
+            {"", null},
+            {null, null},});
+    }
+    
+    @Test
+    public void testRead() {
+        this.<EditorialStatus>testReadProperty(StringTable.EditorialStatus, this.datum, this.expectedResult, new Function<BulkKeywordAdCustomizerAttribute, EditorialStatus>() {
+            @Override
+            public EditorialStatus apply(BulkKeywordAdCustomizerAttribute c) {
+                return c.getEditorialStatus();
+            }
+        });
+    }
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/keyword/read/BulkKeywordAdCustomizerAttributeReadFromRowValuesIdTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/keyword/read/BulkKeywordAdCustomizerAttributeReadFromRowValuesIdTest.java
@@ -1,0 +1,36 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.keyword.read;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.microsoft.bingads.internal.functionalinterfaces.Function;
+import com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.keyword.BulkKeywordAdCustomizerAttributeTest;
+import com.microsoft.bingads.v13.bulk.entities.BulkKeywordAdCustomizerAttribute;
+
+public class BulkKeywordAdCustomizerAttributeReadFromRowValuesIdTest extends BulkKeywordAdCustomizerAttributeTest {
+
+	@Parameter(value = 1)
+    public String expectedResult;
+	
+	@Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"12345678", "12345678"},
+            {"", ""},
+            {null, null},});
+    }
+    
+    @Test
+    public void testRead() {
+        this.<String>testReadProperty("Id", this.datum, this.expectedResult, new Function<BulkKeywordAdCustomizerAttribute, String>() {
+            @Override
+            public String apply(BulkKeywordAdCustomizerAttribute c) {
+                return c.getId();
+            }
+        });
+    }
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/keyword/read/BulkKeywordAdCustomizerAttributeReadFromRowValuesNameTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/keyword/read/BulkKeywordAdCustomizerAttributeReadFromRowValuesNameTest.java
@@ -1,0 +1,37 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.keyword.read;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.microsoft.bingads.internal.functionalinterfaces.Function;
+import com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.keyword.BulkKeywordAdCustomizerAttributeTest;
+import com.microsoft.bingads.v13.bulk.entities.BulkKeywordAdCustomizerAttribute;
+
+public class BulkKeywordAdCustomizerAttributeReadFromRowValuesNameTest extends BulkKeywordAdCustomizerAttributeTest {
+
+	@Parameter(value = 1)
+    public String expectedResult;
+	
+	@Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"Test Name", "Test Name"},
+            {"", ""},
+            {null, null},});
+    }
+    
+    @Test
+    public void testRead() {
+        this.<String>testReadProperty("Name", this.datum, this.expectedResult, new Function<BulkKeywordAdCustomizerAttribute, String>() {
+            @Override
+            public String apply(BulkKeywordAdCustomizerAttribute c) {
+                return c.getName();
+            }
+        });
+    }
+	
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/keyword/read/BulkKeywordAdCustomizerAttributeReadFromRowValuesParentIdTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/keyword/read/BulkKeywordAdCustomizerAttributeReadFromRowValuesParentIdTest.java
@@ -1,0 +1,36 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.keyword.read;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.microsoft.bingads.internal.functionalinterfaces.Function;
+import com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.keyword.BulkKeywordAdCustomizerAttributeTest;
+import com.microsoft.bingads.v13.bulk.entities.BulkKeywordAdCustomizerAttribute;
+
+public class BulkKeywordAdCustomizerAttributeReadFromRowValuesParentIdTest
+		extends BulkKeywordAdCustomizerAttributeTest {
+	
+	@Parameter(value = 1)
+    public Long expectedResult;
+	
+	@Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"123", 123L},
+            {"12345678", 12345678L},});
+    }
+    
+    @Test
+    public void testRead() {
+        this.<Long>testReadProperty("Parent Id", this.datum, this.expectedResult, new Function<BulkKeywordAdCustomizerAttribute, Long>() {
+            @Override
+            public Long apply(BulkKeywordAdCustomizerAttribute c) {
+                return c.getParentId();
+            }
+        });
+    }
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/keyword/read/BulkKeywordAdCustomizerAttributeReadTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/keyword/read/BulkKeywordAdCustomizerAttributeReadTest.java
@@ -1,0 +1,18 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.keyword.read;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+@RunWith(Suite.class)
+@SuiteClasses({
+	BulkKeywordAdCustomizerAttributeReadFromRowValuesIdTest.class,
+	BulkKeywordAdCustomizerAttributeReadFromRowValuesNameTest.class,
+	BulkKeywordAdCustomizerAttributeReadFromRowValuesAttributeValueTest.class,
+	BulkKeywordAdCustomizerAttributeReadFromRowValuesEditorialStatusTest.class,
+	BulkKeywordAdCustomizerAttributeReadFromRowValuesParentIdTest.class
+})
+
+public class BulkKeywordAdCustomizerAttributeReadTest {
+
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/keyword/write/BulkKeywordAdCustomizerAttributeWriteTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/keyword/write/BulkKeywordAdCustomizerAttributeWriteTest.java
@@ -1,0 +1,15 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.keyword.write;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+@RunWith(Suite.class)
+@SuiteClasses({
+	BulkKeywordAdCustomizerAttributeWriteToRowValuesNameTest.class,
+	BulkKeywordAdCustomizerAttributeWriteToRowValuesAttributeValueTest.class,
+	BulkKeywordAdCustomizerAttributeWriteToRowValuesIdTest.class})
+
+public class BulkKeywordAdCustomizerAttributeWriteTest {
+
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/keyword/write/BulkKeywordAdCustomizerAttributeWriteToRowValuesAttributeValueTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/keyword/write/BulkKeywordAdCustomizerAttributeWriteToRowValuesAttributeValueTest.java
@@ -1,0 +1,39 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.keyword.write;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.microsoft.bingads.internal.functionalinterfaces.BiConsumer;
+import com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.keyword.BulkKeywordAdCustomizerAttributeTest;
+import com.microsoft.bingads.v13.bulk.entities.BulkKeywordAdCustomizerAttribute;
+import com.microsoft.bingads.v13.internal.bulk.StringTable;
+
+public class BulkKeywordAdCustomizerAttributeWriteToRowValuesAttributeValueTest
+		extends BulkKeywordAdCustomizerAttributeTest {
+
+	@Parameter(value = 1)
+    public String propertyValue;
+	
+	@Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"Test Attribute Value", "Test Attribute Value"},
+            {"", ""},
+            {null, null},});
+    }
+    
+    @Test
+    public void testWrite() {
+        this.<String>testWriteProperty(StringTable.AdCustomizerAttributeValue, this.datum, this.propertyValue, new BiConsumer<BulkKeywordAdCustomizerAttribute, String>() {
+            @Override
+            public void accept(BulkKeywordAdCustomizerAttribute c, String v) {
+                c.setAttributeValue(v);
+            }
+        });
+    }
+    
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/keyword/write/BulkKeywordAdCustomizerAttributeWriteToRowValuesIdTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/keyword/write/BulkKeywordAdCustomizerAttributeWriteToRowValuesIdTest.java
@@ -1,0 +1,36 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.keyword.write;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.microsoft.bingads.internal.functionalinterfaces.BiConsumer;
+import com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.keyword.BulkKeywordAdCustomizerAttributeTest;
+import com.microsoft.bingads.v13.bulk.entities.BulkKeywordAdCustomizerAttribute;
+
+public class BulkKeywordAdCustomizerAttributeWriteToRowValuesIdTest extends BulkKeywordAdCustomizerAttributeTest {
+	
+	@Parameter(value = 1)
+    public String propertyValue;
+	
+	@Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"12345678", "12345678"},
+            {"", ""},
+            {null, null},});
+    }
+    
+    @Test
+    public void testWrite() {
+        this.<String>testWriteProperty("Id", this.datum, this.propertyValue, new BiConsumer<BulkKeywordAdCustomizerAttribute, String>() {
+            @Override
+            public void accept(BulkKeywordAdCustomizerAttribute c, String v) {
+                c.setId(v);
+            }
+        });
+    }
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/keyword/write/BulkKeywordAdCustomizerAttributeWriteToRowValuesNameTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/keyword/write/BulkKeywordAdCustomizerAttributeWriteToRowValuesNameTest.java
@@ -1,0 +1,40 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.keyword.write;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.microsoft.bingads.internal.functionalinterfaces.BiConsumer;
+import com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.keyword.BulkKeywordAdCustomizerAttributeTest;
+import com.microsoft.bingads.v13.bulk.entities.BulkKeywordAdCustomizerAttribute;
+
+@RunWith(Parameterized.class)
+public class BulkKeywordAdCustomizerAttributeWriteToRowValuesNameTest extends BulkKeywordAdCustomizerAttributeTest {
+	
+	@Parameter(value = 1)
+    public String propertyValue;
+	
+	@Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"Test Name", "Test Name"},
+            {"", ""},
+            {null, null},});
+    }
+    
+    @Test
+    public void testWrite() {
+        this.<String>testWriteProperty("Name", this.datum, this.propertyValue, new BiConsumer<BulkKeywordAdCustomizerAttribute, String>() {
+            @Override
+            public void accept(BulkKeywordAdCustomizerAttribute c, String v) {
+                c.setName(v);
+            }
+        });
+    }
+	
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/read/BulkAdCustomizerAttributeReadFromRowValuesAccountValueTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/read/BulkAdCustomizerAttributeReadFromRowValuesAccountValueTest.java
@@ -1,0 +1,39 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.read;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.microsoft.bingads.internal.functionalinterfaces.Function;
+import com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.BulkAdCustomizerAttributeTest;
+import com.microsoft.bingads.v13.bulk.entities.BulkAdCustomizerAttribute;
+import com.microsoft.bingads.v13.internal.bulk.StringTable;
+
+public class BulkAdCustomizerAttributeReadFromRowValuesAccountValueTest
+		extends BulkAdCustomizerAttributeTest {
+
+	@Parameter(value = 1)
+    public String expectedResult;
+	
+	@Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"Test Account Value", "Test Account Value"},
+            {"", ""},
+            {null, null},});
+    }
+    
+    @Test
+    public void testRead() {
+        this.<String>testReadProperty(StringTable.AdCustomizerAttributeValue, this.datum, this.expectedResult, new Function<BulkAdCustomizerAttribute, String>() {
+            @Override
+            public String apply(BulkAdCustomizerAttribute c) {
+                return c.getAccountValue();
+            }
+        });
+    }
+	
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/read/BulkAdCustomizerAttributeReadFromRowValuesDataTypeTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/read/BulkAdCustomizerAttributeReadFromRowValuesDataTypeTest.java
@@ -1,0 +1,43 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.read;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.microsoft.bingads.internal.functionalinterfaces.Function;
+import com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.BulkAdCustomizerAttributeTest;
+import com.microsoft.bingads.v13.bulk.entities.AttributeType;
+import com.microsoft.bingads.v13.bulk.entities.BulkAdCustomizerAttribute;
+import com.microsoft.bingads.v13.internal.bulk.StringTable;
+
+public class BulkAdCustomizerAttributeReadFromRowValuesDataTypeTest extends BulkAdCustomizerAttributeTest {
+
+	@Parameter(value = 1)
+    public AttributeType expectedResult;
+	
+	@Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+        	{"Number", AttributeType.NUMBER},
+            {"String", AttributeType.STRING},
+            {"Unknow", AttributeType.UNKNOW},
+            {"Price", AttributeType.PRICE},
+            {"Percent", AttributeType.PERCENT},
+            {"", null},
+            {null, null},});
+    }
+    
+    @Test
+    public void testRead() {
+        this.<AttributeType>testReadProperty(StringTable.AdCustomizerDataType, this.datum, this.expectedResult, new Function<BulkAdCustomizerAttribute, AttributeType>() {
+            @Override
+            public AttributeType apply(BulkAdCustomizerAttribute c) {
+                return c.getDataType();
+            }
+        });
+    }
+	
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/read/BulkAdCustomizerAttributeReadFromRowValuesEditorialStatusTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/read/BulkAdCustomizerAttributeReadFromRowValuesEditorialStatusTest.java
@@ -1,0 +1,42 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.read;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.microsoft.bingads.internal.functionalinterfaces.Function;
+import com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.BulkAdCustomizerAttributeTest;
+import com.microsoft.bingads.v13.bulk.entities.BulkAdCustomizerAttribute;
+import com.microsoft.bingads.v13.bulk.entities.EditorialStatus;
+import com.microsoft.bingads.v13.internal.bulk.StringTable;
+
+public class BulkAdCustomizerAttributeReadFromRowValuesEditorialStatusTest
+		extends BulkAdCustomizerAttributeTest {
+	
+	@Parameter(value = 1)
+    public EditorialStatus expectedResult;
+	
+	@Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"Approved", EditorialStatus.APPROVED},
+            {"ApprovedLimited", EditorialStatus.APPROVEDLIMITED},
+            {"Pending", EditorialStatus.PENDING},
+            {"Rejected", EditorialStatus.REJECTED},
+            {"", null},
+            {null, null},});
+    }
+    
+    @Test
+    public void testRead() {
+        this.<EditorialStatus>testReadProperty(StringTable.EditorialStatus, this.datum, this.expectedResult, new Function<BulkAdCustomizerAttribute, EditorialStatus>() {
+            @Override
+            public EditorialStatus apply(BulkAdCustomizerAttribute c) {
+                return c.getEditorialStatus();
+            }
+        });
+    }
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/read/BulkAdCustomizerAttributeReadFromRowValuesIdTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/read/BulkAdCustomizerAttributeReadFromRowValuesIdTest.java
@@ -1,0 +1,36 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.read;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.microsoft.bingads.internal.functionalinterfaces.Function;
+import com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.BulkAdCustomizerAttributeTest;
+import com.microsoft.bingads.v13.bulk.entities.BulkAdCustomizerAttribute;
+
+public class BulkAdCustomizerAttributeReadFromRowValuesIdTest extends BulkAdCustomizerAttributeTest {
+
+	@Parameter(value = 1)
+    public String expectedResult;
+	
+	@Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"12345678", "12345678"},
+            {"", ""},
+            {null, null},});
+    }
+    
+    @Test
+    public void testRead() {
+        this.<String>testReadProperty("Id", this.datum, this.expectedResult, new Function<BulkAdCustomizerAttribute, String>() {
+            @Override
+            public String apply(BulkAdCustomizerAttribute c) {
+                return c.getId();
+            }
+        });
+    }
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/read/BulkAdCustomizerAttributeReadFromRowValuesNameTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/read/BulkAdCustomizerAttributeReadFromRowValuesNameTest.java
@@ -1,0 +1,37 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.read;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.microsoft.bingads.internal.functionalinterfaces.Function;
+import com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.BulkAdCustomizerAttributeTest;
+import com.microsoft.bingads.v13.bulk.entities.BulkAdCustomizerAttribute;
+
+public class BulkAdCustomizerAttributeReadFromRowValuesNameTest extends BulkAdCustomizerAttributeTest {
+
+	@Parameter(value = 1)
+    public String expectedResult;
+	
+	@Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"Test Name", "Test Name"},
+            {"", ""},
+            {null, null},});
+    }
+    
+    @Test
+    public void testRead() {
+        this.<String>testReadProperty("Name", this.datum, this.expectedResult, new Function<BulkAdCustomizerAttribute, String>() {
+            @Override
+            public String apply(BulkAdCustomizerAttribute c) {
+                return c.getName();
+            }
+        });
+    }
+	
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/read/BulkAdCustomizerAttributeReadFromRowValuesStatusTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/read/BulkAdCustomizerAttributeReadFromRowValuesStatusTest.java
@@ -1,0 +1,37 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.read;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.microsoft.bingads.internal.functionalinterfaces.Function;
+import com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.BulkAdCustomizerAttributeTest;
+import com.microsoft.bingads.v13.bulk.entities.BulkAdCustomizerAttribute;
+
+public class BulkAdCustomizerAttributeReadFromRowValuesStatusTest extends BulkAdCustomizerAttributeTest {
+
+	@Parameter(value = 1)
+    public String expectedResult;
+	
+	@Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"Test Status", "Test Status"},
+            {"", ""},
+            {null, null},});
+    }
+    
+    @Test
+    public void testRead() {
+        this.<String>testReadProperty("Status", this.datum, this.expectedResult, new Function<BulkAdCustomizerAttribute, String>() {
+            @Override
+            public String apply(BulkAdCustomizerAttribute c) {
+                return c.getStatus();
+            }
+        });
+    }
+	
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/read/BulkAdCustomizerAttributeReadTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/read/BulkAdCustomizerAttributeReadTest.java
@@ -1,0 +1,19 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.read;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+@RunWith(Suite.class)
+@SuiteClasses({
+	BulkAdCustomizerAttributeReadFromRowValuesEditorialStatusTest.class,
+	BulkAdCustomizerAttributeReadFromRowValuesIdTest.class,
+	BulkAdCustomizerAttributeReadFromRowValuesNameTest.class,
+	BulkAdCustomizerAttributeReadFromRowValuesAccountValueTest.class,
+	BulkAdCustomizerAttributeReadFromRowValuesStatusTest.class,
+	BulkAdCustomizerAttributeReadFromRowValuesDataTypeTest.class
+})
+
+public class BulkAdCustomizerAttributeReadTest {
+
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/write/BulkAdCustomizerAttributeWriteTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/write/BulkAdCustomizerAttributeWriteTest.java
@@ -1,0 +1,16 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.write;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+@RunWith(Suite.class)
+@SuiteClasses({
+	BulkAdCustomizerAttributeWriteToRowValuesNameTest.class,
+	BulkAdCustomizerAttributeWriteToRowValuesAccountValueTest.class,
+	BulkAdCustomizerAttributeWriteToRowValuesDataTypeTest.class
+})
+
+public class BulkAdCustomizerAttributeWriteTest {
+
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/write/BulkAdCustomizerAttributeWriteToRowValuesAccountValueTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/write/BulkAdCustomizerAttributeWriteToRowValuesAccountValueTest.java
@@ -1,0 +1,38 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.write;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.microsoft.bingads.internal.functionalinterfaces.BiConsumer;
+import com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.BulkAdCustomizerAttributeTest;
+import com.microsoft.bingads.v13.bulk.entities.BulkAdCustomizerAttribute;
+import com.microsoft.bingads.v13.internal.bulk.StringTable;
+
+public class BulkAdCustomizerAttributeWriteToRowValuesAccountValueTest extends BulkAdCustomizerAttributeTest {
+
+	@Parameter(value = 1)
+    public String propertyValue;
+	
+	@Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"Test Account Value", "Test Account Value"},
+            {"", ""},
+            {null, null},});
+    }
+    
+    @Test
+    public void testWrite() {
+        this.<String>testWriteProperty(StringTable.AdCustomizerAttributeValue, this.datum, this.propertyValue, new BiConsumer<BulkAdCustomizerAttribute, String>() {
+            @Override
+            public void accept(BulkAdCustomizerAttribute c, String v) {
+                c.setAccountValue(v);
+            }
+        });
+    }
+	
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/write/BulkAdCustomizerAttributeWriteToRowValuesDataTypeTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/write/BulkAdCustomizerAttributeWriteToRowValuesDataTypeTest.java
@@ -1,0 +1,42 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.write;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.microsoft.bingads.internal.functionalinterfaces.BiConsumer;
+import com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.BulkAdCustomizerAttributeTest;
+import com.microsoft.bingads.v13.bulk.entities.AttributeType;
+import com.microsoft.bingads.v13.bulk.entities.BulkAdCustomizerAttribute;
+import com.microsoft.bingads.v13.internal.bulk.StringTable;
+
+public class BulkAdCustomizerAttributeWriteToRowValuesDataTypeTest extends BulkAdCustomizerAttributeTest {
+
+	@Parameter(value = 1)
+    public AttributeType propertyValue;
+	
+	@Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"Number", AttributeType.NUMBER},
+            {"String", AttributeType.STRING},
+            {"Unknow", AttributeType.UNKNOW},
+            {"Price", AttributeType.PRICE},
+            {"Percent", AttributeType.PERCENT},
+            {null, null},});
+    }
+    
+    @Test
+    public void testWrite() {
+        this.<AttributeType>testWriteProperty(StringTable.AdCustomizerDataType, this.datum, this.propertyValue, new BiConsumer<BulkAdCustomizerAttribute, AttributeType>() {
+            @Override
+            public void accept(BulkAdCustomizerAttribute c, AttributeType v) {
+                c.setDataType(v);
+            }
+        });
+    }
+	
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/write/BulkAdCustomizerAttributeWriteToRowValuesNameTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/ad_customizer_attribute/write/BulkAdCustomizerAttributeWriteToRowValuesNameTest.java
@@ -1,0 +1,40 @@
+package com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.write;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.microsoft.bingads.internal.functionalinterfaces.BiConsumer;
+import com.microsoft.bingads.v13.api.test.entities.ad_customizer_attribute.BulkAdCustomizerAttributeTest;
+import com.microsoft.bingads.v13.bulk.entities.BulkAdCustomizerAttribute;
+
+@RunWith(Parameterized.class)
+public class BulkAdCustomizerAttributeWriteToRowValuesNameTest extends BulkAdCustomizerAttributeTest {
+	
+	@Parameter(value = 1)
+    public String propertyValue;
+	
+	@Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"Test Name", "Test Name"},
+            {"", ""},
+            {null, null},});
+    }
+    
+    @Test
+    public void testWrite() {
+        this.<String>testWriteProperty("Name", this.datum, this.propertyValue, new BiConsumer<BulkAdCustomizerAttribute, String>() {
+            @Override
+            public void accept(BulkAdCustomizerAttribute c, String v) {
+                c.setName(v);
+            }
+        });
+    }
+	
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/campaign_conversion_goal/BulkCampaignConversionGoalTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/campaign_conversion_goal/BulkCampaignConversionGoalTest.java
@@ -1,0 +1,123 @@
+package com.microsoft.bingads.v13.api.test.entities.campaign_conversion_goal;
+
+import java.util.Map;
+
+import com.microsoft.bingads.internal.functionalinterfaces.BiConsumer;
+import com.microsoft.bingads.internal.functionalinterfaces.Function;
+import com.microsoft.bingads.internal.functionalinterfaces.Supplier;
+import com.microsoft.bingads.v13.api.test.entities.BulkEntityTest;
+import com.microsoft.bingads.v13.api.test.entities.EqualityComparerWithDescription;
+import com.microsoft.bingads.v13.bulk.entities.BulkCampaignConversionGoal;
+import com.microsoft.bingads.v13.campaignmanagement.CampaignConversionGoal;
+
+public abstract class BulkCampaignConversionGoalTest extends BulkEntityTest<BulkCampaignConversionGoal> {
+
+    @Override
+    protected void onEntityCreation(BulkCampaignConversionGoal entity) {
+        CampaignConversionGoal c = new CampaignConversionGoal();
+        entity.setCampaignConversionGoal(c);
+    }
+
+    @Override
+    protected <TProperty> void testWriteProperty(
+            String header,
+            String expectedRowValue,
+            TProperty propertyValue,
+            BiConsumer<BulkCampaignConversionGoal, TProperty> setFunc
+    ) {
+        testWriteProperty(
+                header,
+                expectedRowValue,
+                propertyValue,
+                setFunc,
+                new Supplier<BulkCampaignConversionGoal>() {
+                    @Override
+                    public BulkCampaignConversionGoal get() {
+                        return new BulkCampaignConversionGoal();
+                    }
+                }
+        );
+    }
+
+    @Override
+    protected <TProperty> void testReadProperty(
+            String header,
+            String input,
+            TProperty expectedResult,
+            Function<BulkCampaignConversionGoal, TProperty> actualValueFunc
+    ) {
+        testReadProperty(
+                header,
+                input,
+                expectedResult,
+                actualValueFunc,
+                new Supplier<BulkCampaignConversionGoal>() {
+                    @Override
+                    public BulkCampaignConversionGoal get() {
+                        return new BulkCampaignConversionGoal();
+                    }
+                }
+        );
+    }
+
+    @Override
+    protected <TProperty> void testReadProperty(
+            Map<String, String> rowValues,
+            TProperty expectedResult,
+            Function<BulkCampaignConversionGoal, TProperty> actualValueFunc
+    ) {
+        testReadProperty(
+                rowValues,
+                expectedResult,
+                actualValueFunc,
+                new Supplier<BulkCampaignConversionGoal>() {
+                    @Override
+                    public BulkCampaignConversionGoal get() {
+                        return new BulkCampaignConversionGoal();
+                    }
+                }
+        );
+    }
+
+    protected <TProperty> void testReadProperty(
+            String header,
+            String input,
+            TProperty expectedResult,
+            Function<BulkCampaignConversionGoal, TProperty> actualValueFunc,
+            EqualityComparerWithDescription<TProperty> comparer
+    ) {
+        testReadProperty(
+                header,
+                input,
+                expectedResult,
+                actualValueFunc,
+                new Supplier<BulkCampaignConversionGoal>() {
+                    @Override
+                    public BulkCampaignConversionGoal get() {
+                        return new BulkCampaignConversionGoal();
+                    }
+                },
+                comparer
+        );
+    }
+
+    protected <TProperty> void testReadProperty(
+            Map<String, String> rowValues,
+            TProperty expectedResult,
+            Function<BulkCampaignConversionGoal, TProperty> actualValueFunc,
+            EqualityComparerWithDescription<TProperty> comparer
+    ) {
+        testReadProperty(
+                rowValues,
+                expectedResult,
+                actualValueFunc,
+                new Supplier<BulkCampaignConversionGoal>() {
+                    @Override
+                    public BulkCampaignConversionGoal get() {
+                        return new BulkCampaignConversionGoal();
+                    }
+                },
+                comparer
+        );
+    }
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/campaign_conversion_goal/BulkCampaignConversionGoalTests.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/campaign_conversion_goal/BulkCampaignConversionGoalTests.java
@@ -1,0 +1,17 @@
+package com.microsoft.bingads.v13.api.test.entities.campaign_conversion_goal;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.microsoft.bingads.v13.api.test.entities.campaign_conversion_goal.read.BulkCampaignConversionGoalReadTests;
+import com.microsoft.bingads.v13.api.test.entities.campaign_conversion_goal.write.BulkCampaignConversionGoalWriteTests;
+
+@RunWith(Suite.class)
+@SuiteClasses({
+        BulkCampaignConversionGoalReadTests.class,
+        BulkCampaignConversionGoalWriteTests.class
+})
+public class BulkCampaignConversionGoalTests {
+
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/campaign_conversion_goal/read/BulkCampaignConversionGoalReadFromRowValuesGoalIdTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/campaign_conversion_goal/read/BulkCampaignConversionGoalReadFromRowValuesGoalIdTest.java
@@ -1,0 +1,36 @@
+package com.microsoft.bingads.v13.api.test.entities.campaign_conversion_goal.read;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.microsoft.bingads.internal.functionalinterfaces.Function;
+import com.microsoft.bingads.v13.api.test.entities.campaign_conversion_goal.BulkCampaignConversionGoalTest;
+import com.microsoft.bingads.v13.bulk.entities.BulkCampaignConversionGoal;
+import com.microsoft.bingads.v13.internal.bulk.StringTable;
+
+public class BulkCampaignConversionGoalReadFromRowValuesGoalIdTest extends BulkCampaignConversionGoalTest {
+
+    @Parameter(value = 1)
+    public Long expectedResult;
+
+    @Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"123", 123L},
+            {"9223372036854775807", 9223372036854775807L},});
+    }
+
+    @Test
+    public void testRead() {
+        this.<Long>testReadProperty(StringTable.GoalId, this.datum, this.expectedResult, new Function<BulkCampaignConversionGoal, Long>() {
+            @Override
+            public Long apply(BulkCampaignConversionGoal c) {
+                return c.getCampaignConversionGoal().getGoalId();
+            }
+        });
+    }
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/campaign_conversion_goal/read/BulkCampaignConversionGoalReadFromRowValuesParentIdTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/campaign_conversion_goal/read/BulkCampaignConversionGoalReadFromRowValuesParentIdTest.java
@@ -1,0 +1,35 @@
+package com.microsoft.bingads.v13.api.test.entities.campaign_conversion_goal.read;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.microsoft.bingads.internal.functionalinterfaces.Function;
+import com.microsoft.bingads.v13.api.test.entities.campaign_conversion_goal.BulkCampaignConversionGoalTest;
+import com.microsoft.bingads.v13.bulk.entities.BulkCampaignConversionGoal;
+
+public class BulkCampaignConversionGoalReadFromRowValuesParentIdTest extends BulkCampaignConversionGoalTest {
+
+    @Parameter(value = 1)
+    public Long expectedResult;
+
+    @Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"123", 123L},
+            {"9223372036854775807", 9223372036854775807L},});
+    }
+
+    @Test
+    public void testRead() {
+        this.<Long>testReadProperty("Parent Id", this.datum, this.expectedResult, new Function<BulkCampaignConversionGoal, Long>() {
+            @Override
+            public Long apply(BulkCampaignConversionGoal c) {
+                return c.getCampaignConversionGoal().getCampaignId();
+            }
+        });
+    }
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/campaign_conversion_goal/read/BulkCampaignConversionGoalReadTests.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/campaign_conversion_goal/read/BulkCampaignConversionGoalReadTests.java
@@ -1,0 +1,15 @@
+package com.microsoft.bingads.v13.api.test.entities.campaign_conversion_goal.read;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+
+@RunWith(Suite.class)
+@SuiteClasses({
+	BulkCampaignConversionGoalReadFromRowValuesParentIdTest.class,
+	BulkCampaignConversionGoalReadFromRowValuesGoalIdTest.class
+})
+public class BulkCampaignConversionGoalReadTests {
+
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/campaign_conversion_goal/write/BulkCampaignConversionGoalWriteTests.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/campaign_conversion_goal/write/BulkCampaignConversionGoalWriteTests.java
@@ -1,0 +1,14 @@
+package com.microsoft.bingads.v13.api.test.entities.campaign_conversion_goal.write;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+@RunWith(Suite.class)
+@SuiteClasses({
+	BulkCampaignConversionGoalWriteToRowValuesParentIdTest.class,
+	BulkCampaignConversionGoalWriteToRowValuesGoalIdTest.class
+})
+public class BulkCampaignConversionGoalWriteTests {
+
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/campaign_conversion_goal/write/BulkCampaignConversionGoalWriteToRowValuesGoalIdTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/campaign_conversion_goal/write/BulkCampaignConversionGoalWriteToRowValuesGoalIdTest.java
@@ -1,0 +1,36 @@
+package com.microsoft.bingads.v13.api.test.entities.campaign_conversion_goal.write;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.microsoft.bingads.internal.functionalinterfaces.BiConsumer;
+import com.microsoft.bingads.v13.api.test.entities.campaign_conversion_goal.BulkCampaignConversionGoalTest;
+import com.microsoft.bingads.v13.bulk.entities.BulkCampaignConversionGoal;
+import com.microsoft.bingads.v13.internal.bulk.StringTable;
+
+public class BulkCampaignConversionGoalWriteToRowValuesGoalIdTest extends BulkCampaignConversionGoalTest {
+
+    @Parameter(value = 1)
+    public Long propertyValue;
+
+    @Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"123", 123L},
+            {"9223372036854775807", 9223372036854775807L},});
+    }
+
+    @Test
+    public void testWrite() {
+        this.<Long>testWriteProperty(StringTable.GoalId, this.datum, this.propertyValue, new BiConsumer<BulkCampaignConversionGoal, Long>() {
+            @Override
+            public void accept(BulkCampaignConversionGoal c, Long v) {
+                c.getCampaignConversionGoal().setGoalId(v);
+            }
+        });
+    }
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/campaign_conversion_goal/write/BulkCampaignConversionGoalWriteToRowValuesParentIdTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/campaign_conversion_goal/write/BulkCampaignConversionGoalWriteToRowValuesParentIdTest.java
@@ -1,0 +1,35 @@
+package com.microsoft.bingads.v13.api.test.entities.campaign_conversion_goal.write;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.microsoft.bingads.internal.functionalinterfaces.BiConsumer;
+import com.microsoft.bingads.v13.api.test.entities.campaign_conversion_goal.BulkCampaignConversionGoalTest;
+import com.microsoft.bingads.v13.bulk.entities.BulkCampaignConversionGoal;
+
+public class BulkCampaignConversionGoalWriteToRowValuesParentIdTest extends BulkCampaignConversionGoalTest {
+
+    @Parameter(value = 1)
+    public Long propertyValue;
+
+    @Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"123", 123L},
+            {"9223372036854775807", 9223372036854775807L},});
+    }
+
+    @Test
+    public void testWrite() {
+        this.<Long>testWriteProperty("Parent Id", this.datum, this.propertyValue, new BiConsumer<BulkCampaignConversionGoal, Long>() {
+            @Override
+            public void accept(BulkCampaignConversionGoal c, Long v) {
+                c.getCampaignConversionGoal().setCampaignId(v);
+            }
+        });
+    }
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/feed/read/BulkFeedReadFromRowValuesScheduleTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/feed/read/BulkFeedReadFromRowValuesScheduleTest.java
@@ -1,0 +1,38 @@
+package com.microsoft.bingads.v13.api.test.entities.feed.read;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.microsoft.bingads.internal.functionalinterfaces.Function;
+import com.microsoft.bingads.v13.api.test.entities.feed.BulkFeedTest;
+import com.microsoft.bingads.v13.bulk.entities.BulkFeed;
+import com.microsoft.bingads.v13.internal.bulk.StringTable;
+
+public class BulkFeedReadFromRowValuesScheduleTest extends BulkFeedTest {
+
+    @Parameter(value = 1)
+    public String expectedResult;
+
+    @Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"Test Feed 1", "Test Feed 1"},
+            {"", ""},
+            {null, null}
+        });
+    }
+
+    @Test
+    public void testRead() {
+        this.<String>testReadProperty(StringTable.Schedule, this.datum, this.expectedResult, new Function<BulkFeed, String>() {
+            @Override
+            public String apply(BulkFeed c) {
+                return c.getSchedule();
+            }
+        });
+    }
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/feed/read/BulkFeedReadTests.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/feed/read/BulkFeedReadTests.java
@@ -10,6 +10,7 @@ import org.junit.runners.Suite.SuiteClasses;
     BulkFeedReadFromRowValuesIdTest.class,
     BulkFeedReadFromRowValuesStatusTest.class,
     BulkFeedReadFromRowValuesParentIdTest.class,
+    BulkFeedReadFromRowValuesScheduleTest.class,
     BulkFeedReadFromRowValuesCustomAttributesTest.class})
 public class BulkFeedReadTests {
 

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/feed/write/BulkFeedWriteTests.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/feed/write/BulkFeedWriteTests.java
@@ -10,6 +10,7 @@ import org.junit.runners.Suite.SuiteClasses;
 	BulkFeedWriteToRowValuesIdTest.class,
 	BulkFeedWriteToRowValuesParentIdTest.class,
 	BulkFeedWriteToRowValuesStatusTest.class,
+	BulkFeedWriteToRowValuesScheduleTest.class,
 	BulkFeedWriteToRowValuesCostomAttributesTest.class})
 public class BulkFeedWriteTests {
 

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/feed/write/BulkFeedWriteToRowValuesScheduleTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/feed/write/BulkFeedWriteToRowValuesScheduleTest.java
@@ -1,0 +1,37 @@
+package com.microsoft.bingads.v13.api.test.entities.feed.write;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.microsoft.bingads.internal.functionalinterfaces.BiConsumer;
+import com.microsoft.bingads.v13.api.test.entities.feed.BulkFeedTest;
+import com.microsoft.bingads.v13.bulk.entities.BulkFeed;
+import com.microsoft.bingads.v13.internal.bulk.StringTable;
+
+public class BulkFeedWriteToRowValuesScheduleTest extends BulkFeedTest {
+
+    @Parameter(value = 1)
+    public String propertyValue;
+
+    @Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"* * 31 12 *", "* * 31 12 *"},
+            {null, null}
+        });
+    }
+
+    @Test
+    public void testWrite() {
+        this.<String>testWriteProperty(StringTable.Schedule, this.datum, this.propertyValue, new BiConsumer<BulkFeed, String>() {
+            @Override
+            public void accept(BulkFeed c, String v) {
+                c.setSchedule(v);
+            }
+        });
+    }
+}


### PR DESCRIPTION
* Update Bing Ads API Version 13 service proxies to reflect recent interface changes. For details please see [the Bing Ads API Release Notes](https://docs.microsoft.com/en-us/bingads/guides/release-notes).
* Add bulk mappings for BulkCampaignConversionGoal.
* Add bulk mappings for ad customer attribute i.e., BulkAdCustomizerAttribute, BulkCampaignAdCustomizerAttribute, BulkAdGroupAdCustomizerAttribute, BulkKeywordAdCustomizerAttribute.
* Add mappings for new fields in BulkFeed: Schedule.
* Fix issue [Create WebPage fails](https://github.com/BingAds/BingAds-Java-SDK/issues/131)