### PR TITLE
v13.0.15.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Bing Ads Java SDK includes and depends on the microsoft.bingads Maven artifa
 <dependency>
   <groupId>com.microsoft.bingads</groupId>
   <artifactId>microsoft.bingads</artifactId>
-  <version>13.0.15</version>
+  <version>13.0.15.1</version>
 </dependency>
 ```
 If you are not using a Maven project, you must include the correct version of each dependency. You can review the complete list of Bing Ads Java SDK dependencies at the [Maven Repository](http://mvnrepository.com/artifact/com.microsoft.bingads/microsoft.bingads/).

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.bingads</groupId>
-    <version>13.0.15</version>
+    <version>13.0.15.1</version>
     <name>Bing Ads Java SDK</name>
     <description>The Bing Ads Java SDK is a library improving developer experience when working with the Bing Ads services by providing high-level access to features such as Bulk API, OAuth Authorization and SOAP API.</description>
     <url>https://github.com/BingAds/BingAds-Java-SDK</url>

--- a/proxies/com/microsoft/bingads/v13/adinsight/IAdInsightService.java
+++ b/proxies/com/microsoft/bingads/v13/adinsight/IAdInsightService.java
@@ -56,8 +56,8 @@ public interface IAdInsightService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.adinsight.GetBidOpportunitiesResponse
-     * @throws ApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetBidOpportunities", action = "GetBidOpportunities")
     @WebResult(name = "GetBidOpportunitiesResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
@@ -97,8 +97,8 @@ public interface IAdInsightService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.adinsight.GetBudgetOpportunitiesResponse
-     * @throws ApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetBudgetOpportunities", action = "GetBudgetOpportunities")
     @WebResult(name = "GetBudgetOpportunitiesResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
@@ -138,8 +138,8 @@ public interface IAdInsightService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.adinsight.GetKeywordOpportunitiesResponse
-     * @throws ApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetKeywordOpportunities", action = "GetKeywordOpportunities")
     @WebResult(name = "GetKeywordOpportunitiesResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
@@ -179,8 +179,8 @@ public interface IAdInsightService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.adinsight.GetEstimatedBidByKeywordIdsResponse
-     * @throws ApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetEstimatedBidByKeywordIds", action = "GetEstimatedBidByKeywordIds")
     @WebResult(name = "GetEstimatedBidByKeywordIdsResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
@@ -220,8 +220,8 @@ public interface IAdInsightService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.adinsight.GetEstimatedPositionByKeywordIdsResponse
-     * @throws ApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetEstimatedPositionByKeywordIds", action = "GetEstimatedPositionByKeywordIds")
     @WebResult(name = "GetEstimatedPositionByKeywordIdsResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
@@ -261,8 +261,8 @@ public interface IAdInsightService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.adinsight.GetEstimatedBidByKeywordsResponse
-     * @throws ApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetEstimatedBidByKeywords", action = "GetEstimatedBidByKeywords")
     @WebResult(name = "GetEstimatedBidByKeywordsResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
@@ -302,8 +302,8 @@ public interface IAdInsightService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.adinsight.GetEstimatedPositionByKeywordsResponse
-     * @throws ApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetEstimatedPositionByKeywords", action = "GetEstimatedPositionByKeywords")
     @WebResult(name = "GetEstimatedPositionByKeywordsResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
@@ -343,8 +343,8 @@ public interface IAdInsightService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.adinsight.GetBidLandscapeByAdGroupIdsResponse
-     * @throws ApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetBidLandscapeByAdGroupIds", action = "GetBidLandscapeByAdGroupIds")
     @WebResult(name = "GetBidLandscapeByAdGroupIdsResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
@@ -384,8 +384,8 @@ public interface IAdInsightService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.adinsight.GetBidLandscapeByKeywordIdsResponse
-     * @throws ApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetBidLandscapeByKeywordIds", action = "GetBidLandscapeByKeywordIds")
     @WebResult(name = "GetBidLandscapeByKeywordIdsResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
@@ -425,8 +425,8 @@ public interface IAdInsightService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.adinsight.GetHistoricalKeywordPerformanceResponse
-     * @throws ApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetHistoricalKeywordPerformance", action = "GetHistoricalKeywordPerformance")
     @WebResult(name = "GetHistoricalKeywordPerformanceResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
@@ -466,8 +466,8 @@ public interface IAdInsightService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.adinsight.GetHistoricalSearchCountResponse
-     * @throws ApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetHistoricalSearchCount", action = "GetHistoricalSearchCount")
     @WebResult(name = "GetHistoricalSearchCountResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
@@ -507,8 +507,8 @@ public interface IAdInsightService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.adinsight.GetKeywordCategoriesResponse
-     * @throws ApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetKeywordCategories", action = "GetKeywordCategories")
     @WebResult(name = "GetKeywordCategoriesResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
@@ -548,8 +548,8 @@ public interface IAdInsightService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.adinsight.GetKeywordDemographicsResponse
-     * @throws ApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetKeywordDemographics", action = "GetKeywordDemographics")
     @WebResult(name = "GetKeywordDemographicsResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
@@ -589,8 +589,8 @@ public interface IAdInsightService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.adinsight.GetKeywordLocationsResponse
-     * @throws ApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetKeywordLocations", action = "GetKeywordLocations")
     @WebResult(name = "GetKeywordLocationsResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
@@ -630,8 +630,8 @@ public interface IAdInsightService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.adinsight.SuggestKeywordsForUrlResponse
-     * @throws ApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFaultDetail_Exception
      */
     @WebMethod(operationName = "SuggestKeywordsForUrl", action = "SuggestKeywordsForUrl")
     @WebResult(name = "SuggestKeywordsForUrlResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
@@ -671,8 +671,8 @@ public interface IAdInsightService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.adinsight.SuggestKeywordsFromExistingKeywordsResponse
-     * @throws ApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFaultDetail_Exception
      */
     @WebMethod(operationName = "SuggestKeywordsFromExistingKeywords", action = "SuggestKeywordsFromExistingKeywords")
     @WebResult(name = "SuggestKeywordsFromExistingKeywordsResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
@@ -712,8 +712,8 @@ public interface IAdInsightService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.adinsight.GetAuctionInsightDataResponse
-     * @throws ApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetAuctionInsightData", action = "GetAuctionInsightData")
     @WebResult(name = "GetAuctionInsightDataResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
@@ -753,8 +753,8 @@ public interface IAdInsightService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.adinsight.GetDomainCategoriesResponse
-     * @throws ApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetDomainCategories", action = "GetDomainCategories")
     @WebResult(name = "GetDomainCategoriesResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
@@ -794,8 +794,8 @@ public interface IAdInsightService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.adinsight.PutMetricDataResponse
-     * @throws ApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFaultDetail_Exception
      */
     @WebMethod(operationName = "PutMetricData", action = "PutMetricData")
     @WebResult(name = "PutMetricDataResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
@@ -835,8 +835,8 @@ public interface IAdInsightService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.adinsight.GetKeywordIdeaCategoriesResponse
-     * @throws ApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetKeywordIdeaCategories", action = "GetKeywordIdeaCategories")
     @WebResult(name = "GetKeywordIdeaCategoriesResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
@@ -876,8 +876,8 @@ public interface IAdInsightService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.adinsight.GetKeywordIdeasResponse
-     * @throws ApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetKeywordIdeas", action = "GetKeywordIdeas")
     @WebResult(name = "GetKeywordIdeasResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
@@ -917,8 +917,8 @@ public interface IAdInsightService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.adinsight.GetKeywordTrafficEstimatesResponse
-     * @throws ApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetKeywordTrafficEstimates", action = "GetKeywordTrafficEstimates")
     @WebResult(name = "GetKeywordTrafficEstimatesResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
@@ -958,8 +958,8 @@ public interface IAdInsightService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.adinsight.GetAutoApplyOptInStatusResponse
-     * @throws ApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetAutoApplyOptInStatus", action = "GetAutoApplyOptInStatus")
     @WebResult(name = "GetAutoApplyOptInStatusResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
@@ -999,8 +999,8 @@ public interface IAdInsightService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.adinsight.SetAutoApplyOptInStatusResponse
-     * @throws ApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFaultDetail_Exception
      */
     @WebMethod(operationName = "SetAutoApplyOptInStatus", action = "SetAutoApplyOptInStatus")
     @WebResult(name = "SetAutoApplyOptInStatusResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
@@ -1040,8 +1040,8 @@ public interface IAdInsightService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.adinsight.GetPerformanceInsightsDetailDataByAccountIdResponse
-     * @throws ApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetPerformanceInsightsDetailDataByAccountId", action = "GetPerformanceInsightsDetailDataByAccountId")
     @WebResult(name = "GetPerformanceInsightsDetailDataByAccountIdResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
@@ -1081,8 +1081,8 @@ public interface IAdInsightService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.adinsight.GetRecommendationsResponse
-     * @throws ApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetRecommendations", action = "GetRecommendations")
     @WebResult(name = "GetRecommendationsResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
@@ -1122,8 +1122,8 @@ public interface IAdInsightService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.adinsight.TagRecommendationsResponse
-     * @throws ApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFaultDetail_Exception
      */
     @WebMethod(operationName = "TagRecommendations", action = "TagRecommendations")
     @WebResult(name = "TagRecommendationsResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")
@@ -1163,8 +1163,8 @@ public interface IAdInsightService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.adinsight.GetTextAssetSuggestionsByFinalUrlsResponse
-     * @throws ApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetTextAssetSuggestionsByFinalUrls", action = "GetTextAssetSuggestionsByFinalUrls")
     @WebResult(name = "GetTextAssetSuggestionsByFinalUrlsResponse", targetNamespace = "https://bingads.microsoft.com/AdInsight/v13", partName = "parameters")

--- a/proxies/com/microsoft/bingads/v13/bulk/BulkService.java
+++ b/proxies/com/microsoft/bingads/v13/bulk/BulkService.java
@@ -17,7 +17,7 @@ import javax.xml.ws.WebServiceFeature;
  * Generated source version: 2.1
  * 
  */
-@WebServiceClient(name = "BulkService", targetNamespace = "https://bingads.microsoft.com/CampaignManagement/v13", wsdlLocation = "https://bulk.api.sandbox.bingads.microsoft.com/Api/Advertiser/CampaignManagement/v13/BulkService.svc?wsdl")
+@WebServiceClient(name = "BulkService", targetNamespace = "https://bingads.microsoft.com/CampaignManagement/v13", wsdlLocation = "https://bulk.api.sandbox.bingads.microsoft.com/Api/Advertiser/CampaignManagement/V13/BulkService.svc?wsdl")
 public class BulkService
     extends Service
 {
@@ -30,7 +30,7 @@ public class BulkService
         URL url = null;
         WebServiceException e = null;
         try {
-            url = new URL("https://bulk.api.sandbox.bingads.microsoft.com/Api/Advertiser/CampaignManagement/v13/BulkService.svc?wsdl");
+            url = new URL("https://bulk.api.sandbox.bingads.microsoft.com/Api/Advertiser/CampaignManagement/V13/BulkService.svc?wsdl");
         } catch (MalformedURLException ex) {
             e = new WebServiceException(ex);
         }

--- a/proxies/com/microsoft/bingads/v13/bulk/IBulkService.java
+++ b/proxies/com/microsoft/bingads/v13/bulk/IBulkService.java
@@ -56,8 +56,8 @@ public interface IBulkService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.bulk.DownloadCampaignsByAccountIdsResponse
-     * @throws ApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFaultDetail_Exception
      */
     @WebMethod(operationName = "DownloadCampaignsByAccountIds", action = "DownloadCampaignsByAccountIds")
     @WebResult(name = "DownloadCampaignsByAccountIdsResponse", targetNamespace = "https://bingads.microsoft.com/CampaignManagement/v13", partName = "parameters")
@@ -97,8 +97,8 @@ public interface IBulkService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.bulk.DownloadCampaignsByCampaignIdsResponse
-     * @throws ApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFaultDetail_Exception
      */
     @WebMethod(operationName = "DownloadCampaignsByCampaignIds", action = "DownloadCampaignsByCampaignIds")
     @WebResult(name = "DownloadCampaignsByCampaignIdsResponse", targetNamespace = "https://bingads.microsoft.com/CampaignManagement/v13", partName = "parameters")
@@ -138,8 +138,8 @@ public interface IBulkService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.bulk.GetBulkDownloadStatusResponse
-     * @throws ApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetBulkDownloadStatus", action = "GetBulkDownloadStatus")
     @WebResult(name = "GetBulkDownloadStatusResponse", targetNamespace = "https://bingads.microsoft.com/CampaignManagement/v13", partName = "parameters")
@@ -179,8 +179,8 @@ public interface IBulkService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.bulk.GetBulkUploadUrlResponse
-     * @throws ApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetBulkUploadUrl", action = "GetBulkUploadUrl")
     @WebResult(name = "GetBulkUploadUrlResponse", targetNamespace = "https://bingads.microsoft.com/CampaignManagement/v13", partName = "parameters")
@@ -220,8 +220,8 @@ public interface IBulkService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.bulk.GetBulkUploadStatusResponse
-     * @throws ApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFaultDetail_Exception
      */
     @WebMethod(operationName = "GetBulkUploadStatus", action = "GetBulkUploadStatus")
     @WebResult(name = "GetBulkUploadStatusResponse", targetNamespace = "https://bingads.microsoft.com/CampaignManagement/v13", partName = "parameters")
@@ -261,8 +261,8 @@ public interface IBulkService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.bulk.UploadEntityRecordsResponse
-     * @throws ApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFaultDetail_Exception
      */
     @WebMethod(operationName = "UploadEntityRecords", action = "UploadEntityRecords")
     @WebResult(name = "UploadEntityRecordsResponse", targetNamespace = "https://bingads.microsoft.com/CampaignManagement/v13", partName = "parameters")

--- a/proxies/com/microsoft/bingads/v13/campaignmanagement/AdGroup.java
+++ b/proxies/com/microsoft/bingads/v13/campaignmanagement/AdGroup.java
@@ -26,6 +26,7 @@ import javax.xml.bind.annotation.XmlType;
  *         &lt;element name="EndDate" type="{https://bingads.microsoft.com/CampaignManagement/v13}Date" minOccurs="0"/>
  *         &lt;element name="FinalUrlSuffix" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/>
  *         &lt;element name="ForwardCompatibilityMap" type="{http://schemas.datacontract.org/2004/07/System.Collections.Generic}ArrayOfKeyValuePairOfstringstring" minOccurs="0"/>
+ *         &lt;element name="FrequencyCapSettings" type="{https://bingads.microsoft.com/CampaignManagement/v13}ArrayOfFrequencyCapSettings" minOccurs="0"/>
  *         &lt;element name="Id" type="{http://www.w3.org/2001/XMLSchema}long" minOccurs="0"/>
  *         &lt;element name="Language" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/>
  *         &lt;element name="MultimediaAdsBidAdjustment" type="{http://www.w3.org/2001/XMLSchema}int" minOccurs="0"/>
@@ -61,6 +62,7 @@ import javax.xml.bind.annotation.XmlType;
     "endDate",
     "finalUrlSuffix",
     "forwardCompatibilityMap",
+    "frequencyCapSettings",
     "id",
     "language",
     "multimediaAdsBidAdjustment",
@@ -97,6 +99,8 @@ public class AdGroup {
     protected String finalUrlSuffix;
     @XmlElement(name = "ForwardCompatibilityMap", nillable = true)
     protected ArrayOfKeyValuePairOfstringstring forwardCompatibilityMap;
+    @XmlElement(name = "FrequencyCapSettings", nillable = true)
+    protected ArrayOfFrequencyCapSettings frequencyCapSettings;
     @XmlElement(name = "Id", nillable = true)
     protected Long id;
     @XmlElement(name = "Language", nillable = true)
@@ -325,6 +329,30 @@ public class AdGroup {
      */
     public void setForwardCompatibilityMap(ArrayOfKeyValuePairOfstringstring value) {
         this.forwardCompatibilityMap = value;
+    }
+
+    /**
+     * Gets the value of the frequencyCapSettings property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link ArrayOfFrequencyCapSettings }
+     *     
+     */
+    public ArrayOfFrequencyCapSettings getFrequencyCapSettings() {
+        return frequencyCapSettings;
+    }
+
+    /**
+     * Sets the value of the frequencyCapSettings property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link ArrayOfFrequencyCapSettings }
+     *     
+     */
+    public void setFrequencyCapSettings(ArrayOfFrequencyCapSettings value) {
+        this.frequencyCapSettings = value;
     }
 
     /**

--- a/proxies/com/microsoft/bingads/v13/campaignmanagement/AdGroupAdditionalField.java
+++ b/proxies/com/microsoft/bingads/v13/campaignmanagement/AdGroupAdditionalField.java
@@ -13,7 +13,8 @@ public enum AdGroupAdditionalField {
     COMMISSION_RATE("CommissionRate"),
     PERCENT_CPC_BID("PercentCpcBid"),
     MCPA_BID("McpaBid"),
-    USE_OPTIMIZED_TARGETING("UseOptimizedTargeting");
+    USE_OPTIMIZED_TARGETING("UseOptimizedTargeting"),
+    FREQUENCY_CAP_SETTINGS("FrequencyCapSettings");
         
     private final String value;
 

--- a/proxies/com/microsoft/bingads/v13/campaignmanagement/ArrayOfFrequencyCapSettings.java
+++ b/proxies/com/microsoft/bingads/v13/campaignmanagement/ArrayOfFrequencyCapSettings.java
@@ -1,0 +1,69 @@
+
+package com.microsoft.bingads.v13.campaignmanagement;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java class for ArrayOfFrequencyCapSettings complex type.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ * 
+ * <pre>
+ * &lt;complexType name="ArrayOfFrequencyCapSettings">
+ *   &lt;complexContent>
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       &lt;sequence>
+ *         &lt;element name="FrequencyCapSettings" type="{https://bingads.microsoft.com/CampaignManagement/v13}FrequencyCapSettings" maxOccurs="unbounded" minOccurs="0"/>
+ *       &lt;/sequence>
+ *     &lt;/restriction>
+ *   &lt;/complexContent>
+ * &lt;/complexType>
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "ArrayOfFrequencyCapSettings", propOrder = {
+    "frequencyCapSettings"
+})
+public class ArrayOfFrequencyCapSettings {
+
+    @XmlElement(name = "FrequencyCapSettings", nillable = true)
+    protected List<FrequencyCapSettings> frequencyCapSettings;
+
+    /**
+     * Gets the value of the frequencyCapSettings property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the frequencyCapSettings property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getFrequencyCapSettings().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link FrequencyCapSettings }
+     * 
+     * 
+     */
+    public List<FrequencyCapSettings> getFrequencyCapSettings() {
+        if (frequencyCapSettings == null) {
+            frequencyCapSettings = new ArrayList<FrequencyCapSettings>();
+        }
+        return this.frequencyCapSettings;
+    }
+
+}

--- a/proxies/com/microsoft/bingads/v13/campaignmanagement/CampaignManagementService.java
+++ b/proxies/com/microsoft/bingads/v13/campaignmanagement/CampaignManagementService.java
@@ -17,7 +17,7 @@ import javax.xml.ws.WebServiceFeature;
  * Generated source version: 2.1
  * 
  */
-@WebServiceClient(name = "CampaignManagementService", targetNamespace = "https://bingads.microsoft.com/CampaignManagement/v13", wsdlLocation = "https://campaign.api.sandbox.bingads.microsoft.com/Api/Advertiser/CampaignManagement/v13/CampaignManagementService.svc?wsdl")
+@WebServiceClient(name = "CampaignManagementService", targetNamespace = "https://bingads.microsoft.com/CampaignManagement/v13", wsdlLocation = "https://campaign.api.sandbox.bingads.microsoft.com/Api/Advertiser/CampaignManagement/V13/CampaignManagementService.svc?wsdl")
 public class CampaignManagementService
     extends Service
 {
@@ -30,7 +30,7 @@ public class CampaignManagementService
         URL url = null;
         WebServiceException e = null;
         try {
-            url = new URL("https://campaign.api.sandbox.bingads.microsoft.com/Api/Advertiser/CampaignManagement/v13/CampaignManagementService.svc?wsdl");
+            url = new URL("https://campaign.api.sandbox.bingads.microsoft.com/Api/Advertiser/CampaignManagement/V13/CampaignManagementService.svc?wsdl");
         } catch (MalformedURLException ex) {
             e = new WebServiceException(ex);
         }

--- a/proxies/com/microsoft/bingads/v13/campaignmanagement/CampaignType.java
+++ b/proxies/com/microsoft/bingads/v13/campaignmanagement/CampaignType.java
@@ -9,7 +9,8 @@ public enum CampaignType {
     SHOPPING("Shopping"),
     DYNAMIC_SEARCH_ADS("DynamicSearchAds"),
     AUDIENCE("Audience"),
-    HOTEL("Hotel");
+    HOTEL("Hotel"),
+    PERFORMANCE_MAX("PerformanceMax");
         
     private final String value;
 

--- a/proxies/com/microsoft/bingads/v13/campaignmanagement/FrequencyCapSettings.java
+++ b/proxies/com/microsoft/bingads/v13/campaignmanagement/FrequencyCapSettings.java
@@ -1,0 +1,120 @@
+
+package com.microsoft.bingads.v13.campaignmanagement;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlSchemaType;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java class for FrequencyCapSettings complex type.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ * 
+ * <pre>
+ * &lt;complexType name="FrequencyCapSettings">
+ *   &lt;complexContent>
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       &lt;sequence>
+ *         &lt;element name="CapValue" type="{http://www.w3.org/2001/XMLSchema}int" minOccurs="0"/>
+ *         &lt;element name="FrequencyCapUnit" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/>
+ *         &lt;element name="TimeGranularity" type="{https://bingads.microsoft.com/CampaignManagement/v13}FrequencyCapTimeGranularity" minOccurs="0"/>
+ *       &lt;/sequence>
+ *     &lt;/restriction>
+ *   &lt;/complexContent>
+ * &lt;/complexType>
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "FrequencyCapSettings", propOrder = {
+    "capValue",
+    "frequencyCapUnit",
+    "timeGranularity"
+})
+public class FrequencyCapSettings {
+
+    @XmlElement(name = "CapValue")
+    protected Integer capValue;
+    @XmlElement(name = "FrequencyCapUnit", nillable = true)
+    protected String frequencyCapUnit;
+    @XmlElement(name = "TimeGranularity")
+    @XmlSchemaType(name = "string")
+    protected FrequencyCapTimeGranularity timeGranularity;
+
+    /**
+     * Gets the value of the capValue property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link Integer }
+     *     
+     */
+    public Integer getCapValue() {
+        return capValue;
+    }
+
+    /**
+     * Sets the value of the capValue property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link Integer }
+     *     
+     */
+    public void setCapValue(Integer value) {
+        this.capValue = value;
+    }
+
+    /**
+     * Gets the value of the frequencyCapUnit property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getFrequencyCapUnit() {
+        return frequencyCapUnit;
+    }
+
+    /**
+     * Sets the value of the frequencyCapUnit property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setFrequencyCapUnit(String value) {
+        this.frequencyCapUnit = value;
+    }
+
+    /**
+     * Gets the value of the timeGranularity property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link FrequencyCapTimeGranularity }
+     *     
+     */
+    public FrequencyCapTimeGranularity getTimeGranularity() {
+        return timeGranularity;
+    }
+
+    /**
+     * Sets the value of the timeGranularity property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link FrequencyCapTimeGranularity }
+     *     
+     */
+    public void setTimeGranularity(FrequencyCapTimeGranularity value) {
+        this.timeGranularity = value;
+    }
+
+}

--- a/proxies/com/microsoft/bingads/v13/campaignmanagement/FrequencyCapTimeGranularity.java
+++ b/proxies/com/microsoft/bingads/v13/campaignmanagement/FrequencyCapTimeGranularity.java
@@ -1,0 +1,44 @@
+
+package com.microsoft.bingads.v13.campaignmanagement;
+
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java class for FrequencyCapTimeGranularity.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>
+ * <pre>
+ * &lt;simpleType name="FrequencyCapTimeGranularity">
+ *   &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string">
+ *     &lt;enumeration value="HOUR"/>
+ *     &lt;enumeration value="DAY"/>
+ *     &lt;enumeration value="WEEK"/>
+ *     &lt;enumeration value="MONTH"/>
+ *     &lt;enumeration value="LIFETIME"/>
+ *   &lt;/restriction>
+ * &lt;/simpleType>
+ * </pre>
+ * 
+ */
+@XmlType(name = "FrequencyCapTimeGranularity")
+@XmlEnum
+public enum FrequencyCapTimeGranularity {
+
+    HOUR,
+    DAY,
+    WEEK,
+    MONTH,
+    LIFETIME;
+
+    public String value() {
+        return name();
+    }
+
+    public static FrequencyCapTimeGranularity fromValue(String v) {
+        return valueOf(v);
+    }
+
+}

--- a/proxies/com/microsoft/bingads/v13/campaignmanagement/GoogleImportOption.java
+++ b/proxies/com/microsoft/bingads/v13/campaignmanagement/GoogleImportOption.java
@@ -77,6 +77,7 @@ import javax.xml.bind.annotation.XmlType;
  *         &lt;element name="UpdateAdCustomizerFeeds" type="{http://www.w3.org/2001/XMLSchema}boolean" minOccurs="0"/>
  *         &lt;element name="UpdateAdGroupNetwork" type="{http://www.w3.org/2001/XMLSchema}boolean" minOccurs="0"/>
  *         &lt;element name="UpdateAdSchedules" type="{http://www.w3.org/2001/XMLSchema}boolean" minOccurs="0"/>
+ *         &lt;element name="UpdateAdUrls" type="{http://www.w3.org/2001/XMLSchema}boolean" minOccurs="0"/>
  *         &lt;element name="UpdateAppAdExtensions" type="{http://www.w3.org/2001/XMLSchema}boolean" minOccurs="0"/>
  *         &lt;element name="UpdateAudienceTargets" type="{http://www.w3.org/2001/XMLSchema}boolean" minOccurs="0"/>
  *         &lt;element name="UpdateBiddingStrategies" type="{http://www.w3.org/2001/XMLSchema}boolean" minOccurs="0"/>
@@ -178,6 +179,7 @@ import javax.xml.bind.annotation.XmlType;
     "updateAdCustomizerFeeds",
     "updateAdGroupNetwork",
     "updateAdSchedules",
+    "updateAdUrls",
     "updateAppAdExtensions",
     "updateAudienceTargets",
     "updateBiddingStrategies",
@@ -334,6 +336,8 @@ public class GoogleImportOption
     protected Boolean updateAdGroupNetwork;
     @XmlElement(name = "UpdateAdSchedules", nillable = true)
     protected Boolean updateAdSchedules;
+    @XmlElement(name = "UpdateAdUrls", nillable = true)
+    protected Boolean updateAdUrls;
     @XmlElement(name = "UpdateAppAdExtensions", nillable = true)
     protected Boolean updateAppAdExtensions;
     @XmlElement(name = "UpdateAudienceTargets", nillable = true)
@@ -1835,6 +1839,30 @@ public class GoogleImportOption
      */
     public void setUpdateAdSchedules(Boolean value) {
         this.updateAdSchedules = value;
+    }
+
+    /**
+     * Gets the value of the updateAdUrls property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link Boolean }
+     *     
+     */
+    public Boolean getUpdateAdUrls() {
+        return updateAdUrls;
+    }
+
+    /**
+     * Sets the value of the updateAdUrls property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link Boolean }
+     *     
+     */
+    public void setUpdateAdUrls(Boolean value) {
+        this.updateAdUrls = value;
     }
 
     /**

--- a/proxies/com/microsoft/bingads/v13/campaignmanagement/ICampaignManagementService.java
+++ b/proxies/com/microsoft/bingads/v13/campaignmanagement/ICampaignManagementService.java
@@ -999,8 +999,8 @@ public interface ICampaignManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.campaignmanagement.AddKeywordsResponse
-     * @throws EditorialApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws EditorialApiFaultDetail_Exception
      */
     @WebMethod(operationName = "AddKeywords", action = "AddKeywords")
     @WebResult(name = "AddKeywordsResponse", targetNamespace = "https://bingads.microsoft.com/CampaignManagement/v13", partName = "parameters")
@@ -1655,8 +1655,8 @@ public interface ICampaignManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.campaignmanagement.SetAdExtensionsAssociationsResponse
-     * @throws EditorialApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws EditorialApiFaultDetail_Exception
      */
     @WebMethod(operationName = "SetAdExtensionsAssociations", action = "SetAdExtensionsAssociations")
     @WebResult(name = "SetAdExtensionsAssociationsResponse", targetNamespace = "https://bingads.microsoft.com/CampaignManagement/v13", partName = "parameters")
@@ -2065,8 +2065,8 @@ public interface ICampaignManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.campaignmanagement.AddAdGroupCriterionsResponse
-     * @throws EditorialApiFaultDetail_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws EditorialApiFaultDetail_Exception
      */
     @WebMethod(operationName = "AddAdGroupCriterions", action = "AddAdGroupCriterions")
     @WebResult(name = "AddAdGroupCriterionsResponse", targetNamespace = "https://bingads.microsoft.com/CampaignManagement/v13", partName = "parameters")

--- a/proxies/com/microsoft/bingads/v13/campaignmanagement/ImportAdditionalField.java
+++ b/proxies/com/microsoft/bingads/v13/campaignmanagement/ImportAdditionalField.java
@@ -14,7 +14,8 @@ public enum ImportAdditionalField {
     NEW_IMAGE_AD_EXTENSIONS("NewImageAdExtensions"),
     UPDATE_IMAGE_AD_EXTENSIONS("UpdateImageAdExtensions"),
     SEARCH_AND_REPLACE_FOR_FINAL_U_R_L_SUFFIX("SearchAndReplaceForFinalURLSuffix"),
-    RENAME_CAMPAIGN_NAME_WITH_SUFFIX("RenameCampaignNameWithSuffix");
+    RENAME_CAMPAIGN_NAME_WITH_SUFFIX("RenameCampaignNameWithSuffix"),
+    UPDATE_AD_URLS("UpdateAdUrls");
         
     private final String value;
 

--- a/proxies/com/microsoft/bingads/v13/campaignmanagement/ObjectFactory.java
+++ b/proxies/com/microsoft/bingads/v13/campaignmanagement/ObjectFactory.java
@@ -159,6 +159,7 @@ public class ObjectFactory {
     private final static QName _PriceTableRow_QNAME = new QName("https://bingads.microsoft.com/CampaignManagement/v13", "PriceTableRow");
     private final static QName _CampaignCriterion_QNAME = new QName("https://bingads.microsoft.com/CampaignManagement/v13", "CampaignCriterion");
     private final static QName _PriceAdExtension_QNAME = new QName("https://bingads.microsoft.com/CampaignManagement/v13", "PriceAdExtension");
+    private final static QName _ArrayOfFrequencyCapSettings_QNAME = new QName("https://bingads.microsoft.com/CampaignManagement/v13", "ArrayOfFrequencyCapSettings");
     private final static QName _ArrayOfTargetSettingDetail_QNAME = new QName("https://bingads.microsoft.com/CampaignManagement/v13", "ArrayOfTargetSettingDetail");
     private final static QName _CustomerAccountShare_QNAME = new QName("https://bingads.microsoft.com/CampaignManagement/v13", "CustomerAccountShare");
     private final static QName _ImportJob_QNAME = new QName("https://bingads.microsoft.com/CampaignManagement/v13", "ImportJob");
@@ -189,8 +190,10 @@ public class ObjectFactory {
     private final static QName _AppealStatus_QNAME = new QName("https://bingads.microsoft.com/CampaignManagement/v13", "AppealStatus");
     private final static QName _DisclaimerAdExtension_QNAME = new QName("https://bingads.microsoft.com/CampaignManagement/v13", "DisclaimerAdExtension");
     private final static QName _BatchError_QNAME = new QName("https://bingads.microsoft.com/CampaignManagement/v13", "BatchError");
+    private final static QName _PerformanceMaxSetting_QNAME = new QName("https://bingads.microsoft.com/CampaignManagement/v13", "PerformanceMaxSetting");
     private final static QName _ProfileType_QNAME = new QName("https://bingads.microsoft.com/CampaignManagement/v13", "ProfileType");
     private final static QName _AdRotationType_QNAME = new QName("https://bingads.microsoft.com/CampaignManagement/v13", "AdRotationType");
+    private final static QName _FrequencyCapTimeGranularity_QNAME = new QName("https://bingads.microsoft.com/CampaignManagement/v13", "FrequencyCapTimeGranularity");
     private final static QName _CustomParameters_QNAME = new QName("https://bingads.microsoft.com/CampaignManagement/v13", "CustomParameters");
     private final static QName _ArrayOfAccountPropertyName_QNAME = new QName("https://bingads.microsoft.com/CampaignManagement/v13", "ArrayOfAccountPropertyName");
     private final static QName _Char_QNAME = new QName("http://schemas.microsoft.com/2003/10/Serialization/", "char");
@@ -331,6 +334,7 @@ public class ObjectFactory {
     private final static QName _AccountProperty_QNAME = new QName("https://bingads.microsoft.com/CampaignManagement/v13", "AccountProperty");
     private final static QName _CriterionBid_QNAME = new QName("https://bingads.microsoft.com/CampaignManagement/v13", "CriterionBid");
     private final static QName _ArrayOfAdApiError_QNAME = new QName("https://adapi.microsoft.com", "ArrayOfAdApiError");
+    private final static QName _FrequencyCapSettings_QNAME = new QName("https://bingads.microsoft.com/CampaignManagement/v13", "FrequencyCapSettings");
     private final static QName _AudienceCriterion_QNAME = new QName("https://bingads.microsoft.com/CampaignManagement/v13", "AudienceCriterion");
     private final static QName _Bid_QNAME = new QName("https://bingads.microsoft.com/CampaignManagement/v13", "Bid");
     private final static QName _ProductAudienceType_QNAME = new QName("https://bingads.microsoft.com/CampaignManagement/v13", "ProductAudienceType");
@@ -1609,6 +1613,14 @@ public class ObjectFactory {
      */
     public AddAdGroupsResponse createAddAdGroupsResponse() {
         return new AddAdGroupsResponse();
+    }
+
+    /**
+     * Create an instance of {@link FrequencyCapSettings }
+     * 
+     */
+    public FrequencyCapSettings createFrequencyCapSettings() {
+        return new FrequencyCapSettings();
     }
 
     /**
@@ -3172,6 +3184,14 @@ public class ObjectFactory {
     }
 
     /**
+     * Create an instance of {@link PerformanceMaxSetting }
+     * 
+     */
+    public PerformanceMaxSetting createPerformanceMaxSetting() {
+        return new PerformanceMaxSetting();
+    }
+
+    /**
      * Create an instance of {@link DisclaimerAdExtension }
      * 
      */
@@ -3481,6 +3501,14 @@ public class ObjectFactory {
      */
     public ArrayOfTargetSettingDetail createArrayOfTargetSettingDetail() {
         return new ArrayOfTargetSettingDetail();
+    }
+
+    /**
+     * Create an instance of {@link ArrayOfFrequencyCapSettings }
+     * 
+     */
+    public ArrayOfFrequencyCapSettings createArrayOfFrequencyCapSettings() {
+        return new ArrayOfFrequencyCapSettings();
     }
 
     /**
@@ -6060,6 +6088,15 @@ public class ObjectFactory {
     }
 
     /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfFrequencyCapSettings }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/CampaignManagement/v13", name = "ArrayOfFrequencyCapSettings")
+    public JAXBElement<ArrayOfFrequencyCapSettings> createArrayOfFrequencyCapSettings(ArrayOfFrequencyCapSettings value) {
+        return new JAXBElement<ArrayOfFrequencyCapSettings>(_ArrayOfFrequencyCapSettings_QNAME, ArrayOfFrequencyCapSettings.class, null, value);
+    }
+
+    /**
      * Create an instance of {@link JAXBElement }{@code <}{@link ArrayOfTargetSettingDetail }{@code >}}
      * 
      */
@@ -6330,6 +6367,15 @@ public class ObjectFactory {
     }
 
     /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link PerformanceMaxSetting }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/CampaignManagement/v13", name = "PerformanceMaxSetting")
+    public JAXBElement<PerformanceMaxSetting> createPerformanceMaxSetting(PerformanceMaxSetting value) {
+        return new JAXBElement<PerformanceMaxSetting>(_PerformanceMaxSetting_QNAME, PerformanceMaxSetting.class, null, value);
+    }
+
+    /**
      * Create an instance of {@link JAXBElement }{@code <}{@link Collection }{@code <}{@link ProfileType }{@code >}{@code >}}
      * 
      */
@@ -6346,6 +6392,15 @@ public class ObjectFactory {
     @XmlElementDecl(namespace = "https://bingads.microsoft.com/CampaignManagement/v13", name = "AdRotationType")
     public JAXBElement<AdRotationType> createAdRotationType(AdRotationType value) {
         return new JAXBElement<AdRotationType>(_AdRotationType_QNAME, AdRotationType.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link FrequencyCapTimeGranularity }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/CampaignManagement/v13", name = "FrequencyCapTimeGranularity")
+    public JAXBElement<FrequencyCapTimeGranularity> createFrequencyCapTimeGranularity(FrequencyCapTimeGranularity value) {
+        return new JAXBElement<FrequencyCapTimeGranularity>(_FrequencyCapTimeGranularity_QNAME, FrequencyCapTimeGranularity.class, null, value);
     }
 
     /**
@@ -7614,6 +7669,15 @@ public class ObjectFactory {
     @XmlElementDecl(namespace = "https://adapi.microsoft.com", name = "ArrayOfAdApiError")
     public JAXBElement<ArrayOfAdApiError> createArrayOfAdApiError(ArrayOfAdApiError value) {
         return new JAXBElement<ArrayOfAdApiError>(_ArrayOfAdApiError_QNAME, ArrayOfAdApiError.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link FrequencyCapSettings }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "https://bingads.microsoft.com/CampaignManagement/v13", name = "FrequencyCapSettings")
+    public JAXBElement<FrequencyCapSettings> createFrequencyCapSettings(FrequencyCapSettings value) {
+        return new JAXBElement<FrequencyCapSettings>(_FrequencyCapSettings_QNAME, FrequencyCapSettings.class, null, value);
     }
 
     /**

--- a/proxies/com/microsoft/bingads/v13/campaignmanagement/PerformanceMaxSetting.java
+++ b/proxies/com/microsoft/bingads/v13/campaignmanagement/PerformanceMaxSetting.java
@@ -1,0 +1,64 @@
+
+package com.microsoft.bingads.v13.campaignmanagement;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java class for PerformanceMaxSetting complex type.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ * 
+ * <pre>
+ * &lt;complexType name="PerformanceMaxSetting">
+ *   &lt;complexContent>
+ *     &lt;extension base="{https://bingads.microsoft.com/CampaignManagement/v13}Setting">
+ *       &lt;sequence>
+ *         &lt;element name="FinalUrlExpansionOptOut" type="{http://www.w3.org/2001/XMLSchema}boolean" minOccurs="0"/>
+ *       &lt;/sequence>
+ *     &lt;/extension>
+ *   &lt;/complexContent>
+ * &lt;/complexType>
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "PerformanceMaxSetting", propOrder = {
+    "finalUrlExpansionOptOut"
+})
+public class PerformanceMaxSetting
+    extends Setting
+{
+
+    @XmlElement(name = "FinalUrlExpansionOptOut")
+    protected Boolean finalUrlExpansionOptOut;
+
+    /**
+     * Gets the value of the finalUrlExpansionOptOut property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link Boolean }
+     *     
+     */
+    public Boolean getFinalUrlExpansionOptOut() {
+        return finalUrlExpansionOptOut;
+    }
+
+    /**
+     * Sets the value of the finalUrlExpansionOptOut property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link Boolean }
+     *     
+     */
+    public void setFinalUrlExpansionOptOut(Boolean value) {
+        this.finalUrlExpansionOptOut = value;
+    }
+
+}

--- a/proxies/com/microsoft/bingads/v13/campaignmanagement/Setting.java
+++ b/proxies/com/microsoft/bingads/v13/campaignmanagement/Setting.java
@@ -37,6 +37,7 @@ import javax.xml.bind.annotation.XmlType;
     DynamicFeedSetting.class,
     DynamicSearchAdsSetting.class,
     ShoppingSetting.class,
+    PerformanceMaxSetting.class,
     VerifiedTrackingSetting.class,
     CoOpSetting.class,
     ResponsiveSearchAdsSetting.class,

--- a/proxies/com/microsoft/bingads/v13/customerbilling/ICustomerBillingService.java
+++ b/proxies/com/microsoft/bingads/v13/customerbilling/ICustomerBillingService.java
@@ -56,9 +56,9 @@ public interface ICustomerBillingService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customerbilling.GetBillingDocumentsInfoResponse
-     * @throws ApiBatchFault_Exception
-     * @throws ApiFault_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFault_Exception
+     * @throws ApiBatchFault_Exception
      */
     @WebMethod(operationName = "GetBillingDocumentsInfo", action = "GetBillingDocumentsInfo")
     @WebResult(name = "GetBillingDocumentsInfoResponse", targetNamespace = "https://bingads.microsoft.com/Billing/v13", partName = "parameters")
@@ -98,9 +98,9 @@ public interface ICustomerBillingService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customerbilling.GetBillingDocumentsResponse
-     * @throws ApiBatchFault_Exception
-     * @throws ApiFault_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFault_Exception
+     * @throws ApiBatchFault_Exception
      */
     @WebMethod(operationName = "GetBillingDocuments", action = "GetBillingDocuments")
     @WebResult(name = "GetBillingDocumentsResponse", targetNamespace = "https://bingads.microsoft.com/Billing/v13", partName = "parameters")
@@ -140,8 +140,8 @@ public interface ICustomerBillingService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customerbilling.AddInsertionOrderResponse
-     * @throws ApiFault_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFault_Exception
      */
     @WebMethod(operationName = "AddInsertionOrder", action = "AddInsertionOrder")
     @WebResult(name = "AddInsertionOrderResponse", targetNamespace = "https://bingads.microsoft.com/Billing/v13", partName = "parameters")
@@ -181,8 +181,8 @@ public interface ICustomerBillingService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customerbilling.UpdateInsertionOrderResponse
-     * @throws ApiFault_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFault_Exception
      */
     @WebMethod(operationName = "UpdateInsertionOrder", action = "UpdateInsertionOrder")
     @WebResult(name = "UpdateInsertionOrderResponse", targetNamespace = "https://bingads.microsoft.com/Billing/v13", partName = "parameters")
@@ -222,8 +222,8 @@ public interface ICustomerBillingService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customerbilling.SearchInsertionOrdersResponse
-     * @throws ApiFault_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFault_Exception
      */
     @WebMethod(operationName = "SearchInsertionOrders", action = "SearchInsertionOrders")
     @WebResult(name = "SearchInsertionOrdersResponse", targetNamespace = "https://bingads.microsoft.com/Billing/v13", partName = "parameters")
@@ -263,8 +263,8 @@ public interface ICustomerBillingService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customerbilling.GetAccountMonthlySpendResponse
-     * @throws ApiFault_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFault_Exception
      */
     @WebMethod(operationName = "GetAccountMonthlySpend", action = "GetAccountMonthlySpend")
     @WebResult(name = "GetAccountMonthlySpendResponse", targetNamespace = "https://bingads.microsoft.com/Billing/v13", partName = "parameters")
@@ -304,8 +304,8 @@ public interface ICustomerBillingService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customerbilling.DispatchCouponsResponse
-     * @throws ApiFault_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFault_Exception
      */
     @WebMethod(operationName = "DispatchCoupons", action = "DispatchCoupons")
     @WebResult(name = "DispatchCouponsResponse", targetNamespace = "https://bingads.microsoft.com/Billing/v13", partName = "parameters")
@@ -345,8 +345,8 @@ public interface ICustomerBillingService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customerbilling.RedeemCouponResponse
-     * @throws ApiFault_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFault_Exception
      */
     @WebMethod(operationName = "RedeemCoupon", action = "RedeemCoupon")
     @WebResult(name = "RedeemCouponResponse", targetNamespace = "https://bingads.microsoft.com/Billing/v13", partName = "parameters")
@@ -386,8 +386,8 @@ public interface ICustomerBillingService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customerbilling.SearchCouponsResponse
-     * @throws ApiFault_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFault_Exception
      */
     @WebMethod(operationName = "SearchCoupons", action = "SearchCoupons")
     @WebResult(name = "SearchCouponsResponse", targetNamespace = "https://bingads.microsoft.com/Billing/v13", partName = "parameters")

--- a/proxies/com/microsoft/bingads/v13/customermanagement/ICustomerManagementService.java
+++ b/proxies/com/microsoft/bingads/v13/customermanagement/ICustomerManagementService.java
@@ -179,8 +179,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.UpdateAccountResponse
-     * @throws ApiFault_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFault_Exception
      */
     @WebMethod(operationName = "UpdateAccount", action = "UpdateAccount")
     @WebResult(name = "UpdateAccountResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -384,8 +384,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.GetCustomersInfoResponse
-     * @throws ApiFault_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFault_Exception
      */
     @WebMethod(operationName = "GetCustomersInfo", action = "GetCustomersInfo")
     @WebResult(name = "GetCustomersInfoResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -466,8 +466,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.DeleteCustomerResponse
-     * @throws ApiFault_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFault_Exception
      */
     @WebMethod(operationName = "DeleteCustomer", action = "DeleteCustomer")
     @WebResult(name = "DeleteCustomerResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -548,8 +548,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.UpdateUserRolesResponse
-     * @throws ApiFault_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFault_Exception
      */
     @WebMethod(operationName = "UpdateUserRoles", action = "UpdateUserRoles")
     @WebResult(name = "UpdateUserRolesResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -712,8 +712,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.GetUsersInfoResponse
-     * @throws ApiFault_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFault_Exception
      */
     @WebMethod(operationName = "GetUsersInfo", action = "GetUsersInfo")
     @WebResult(name = "GetUsersInfoResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -999,8 +999,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.AddPrepayAccountResponse
-     * @throws ApiFault_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFault_Exception
      */
     @WebMethod(operationName = "AddPrepayAccount", action = "AddPrepayAccount")
     @WebResult(name = "AddPrepayAccountResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -1081,8 +1081,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.MapCustomerIdToExternalCustomerIdResponse
-     * @throws ApiFault_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFault_Exception
      */
     @WebMethod(operationName = "MapCustomerIdToExternalCustomerId", action = "MapCustomerIdToExternalCustomerId")
     @WebResult(name = "MapCustomerIdToExternalCustomerIdResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -1204,8 +1204,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.AddClientLinksResponse
-     * @throws ApiFault_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFault_Exception
      */
     @WebMethod(operationName = "AddClientLinks", action = "AddClientLinks")
     @WebResult(name = "AddClientLinksResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -1245,8 +1245,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.UpdateClientLinksResponse
-     * @throws ApiFault_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFault_Exception
      */
     @WebMethod(operationName = "UpdateClientLinks", action = "UpdateClientLinks")
     @WebResult(name = "UpdateClientLinksResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")
@@ -1368,8 +1368,8 @@ public interface ICustomerManagementService {
      * @param parameters
      * @return
      *     returns com.microsoft.bingads.v13.customermanagement.SendUserInvitationResponse
-     * @throws ApiFault_Exception
      * @throws AdApiFaultDetail_Exception
+     * @throws ApiFault_Exception
      */
     @WebMethod(operationName = "SendUserInvitation", action = "SendUserInvitation")
     @WebResult(name = "SendUserInvitationResponse", targetNamespace = "https://bingads.microsoft.com/Customer/v13", partName = "parameters")

--- a/src/main/java/com/microsoft/bingads/internal/ServiceFactoryImpl.java
+++ b/src/main/java/com/microsoft/bingads/internal/ServiceFactoryImpl.java
@@ -29,7 +29,7 @@ import com.microsoft.bingads.InternalException;
 
 public class ServiceFactoryImpl implements ServiceFactory {
 
-    private static final String VERSION = "13.0.15";
+    private static final String VERSION = "13.0.15.1";
     
     private static final int DEFAULT_WS_CREATE_TIMEOUT_IN_SECOND = 60;
     

--- a/src/main/java/com/microsoft/bingads/v13/bulk/entities/BulkAdGroup.java
+++ b/src/main/java/com/microsoft/bingads/v13/bulk/entities/BulkAdGroup.java
@@ -583,7 +583,22 @@ public class BulkAdGroup extends SingleRecordBulkEntity {
                     }
                 }
         ));
-
+        
+        m.add(new SimpleBulkMapping<BulkAdGroup, String>(StringTable.FrequencyCapSettings,
+                new Function<BulkAdGroup, String>() {
+                    @Override
+                    public String apply(BulkAdGroup c) {
+                        return StringExtensions.toAdGroupFrequencyCapSettingsBulkString(c.getAdGroup().getFrequencyCapSettings(), c.getAdGroup().getId());
+                    }
+                },
+                new BiConsumer<String, BulkAdGroup>() {
+                    @Override
+                    public void accept(String v, BulkAdGroup c) {
+                        c.getAdGroup().setFrequencyCapSettings(StringExtensions.parseFrequencyCapSettings(v));
+                    }
+                }
+        ));
+        
         MAPPINGS = Collections.unmodifiableList(m);
     }
     

--- a/src/main/java/com/microsoft/bingads/v13/internal/bulk/CsvHeaders.java
+++ b/src/main/java/com/microsoft/bingads/v13/internal/bulk/CsvHeaders.java
@@ -49,6 +49,7 @@ public class CsvHeaders {
             StringTable.AdGroupType,
             StringTable.CpvBid,
             StringTable.CpmBid,
+            StringTable.FrequencyCapSettings,
             StringTable.HotelAdGroupType,
             StringTable.CommissionRate,
             StringTable.PercentCpcBid,

--- a/src/main/java/com/microsoft/bingads/v13/internal/bulk/StringExtensions.java
+++ b/src/main/java/com/microsoft/bingads/v13/internal/bulk/StringExtensions.java
@@ -36,6 +36,7 @@ import com.microsoft.bingads.v13.campaignmanagement.ArrayOfAssetLink;
 import com.microsoft.bingads.v13.campaignmanagement.ArrayOfCombinationRule;
 import com.microsoft.bingads.v13.campaignmanagement.ArrayOfCustomParameter;
 import com.microsoft.bingads.v13.campaignmanagement.ArrayOfDayTime;
+import com.microsoft.bingads.v13.campaignmanagement.ArrayOfFrequencyCapSettings;
 import com.microsoft.bingads.v13.campaignmanagement.ArrayOfKeyValuePairOfstringstring;
 import com.microsoft.bingads.v13.campaignmanagement.ArrayOfRuleItem;
 import com.microsoft.bingads.v13.campaignmanagement.ArrayOfRuleItemGroup;
@@ -58,6 +59,7 @@ import com.microsoft.bingads.v13.campaignmanagement.Day;
 import com.microsoft.bingads.v13.campaignmanagement.DayTime;
 import com.microsoft.bingads.v13.campaignmanagement.EnhancedCpcBiddingScheme;
 import com.microsoft.bingads.v13.campaignmanagement.FixedBid;
+import com.microsoft.bingads.v13.campaignmanagement.FrequencyCapSettings;
 import com.microsoft.bingads.v13.campaignmanagement.HotelAdGroupType;
 import com.microsoft.bingads.v13.campaignmanagement.HotelSetting;
 import com.microsoft.bingads.v13.campaignmanagement.ImageAsset;
@@ -537,6 +539,59 @@ public class StringExtensions {
         }
         
         return bid.getAmount().toString();
+    }
+    
+    public static String toAdGroupFrequencyCapSettingsBulkString(ArrayOfFrequencyCapSettings settings, Long id)
+    {
+    	if (settings == null || settings.getFrequencyCapSettings() == null) {
+    		return null;
+    	}
+    	
+    	if (settings.getFrequencyCapSettings().size() == 0) {
+    		return id != null && id > 0 ? StringTable.DeleteValue : null;
+    	}
+    	
+    	StringBuilder sb = new StringBuilder(256);
+    	sb.append('[');
+    	for (FrequencyCapSettings setting : settings.getFrequencyCapSettings()) {
+    		sb.append("{\"capValue\":")
+    		  .append(setting.getCapValue())
+    		  .append(",\"frequencyCapUnit\":\"")
+    		  .append(setting.getFrequencyCapUnit())
+    		  .append("\",\"timeGranularity\":\"")
+    		  .append(setting.getTimeGranularity().toString())
+    		  .append("\"},");
+    	}
+    	if (settings.getFrequencyCapSettings().size() > 0) {
+    		sb.deleteCharAt(sb.length() - 1);
+    	}
+    	sb.append("]");
+    	return sb.toString();
+    }
+    
+    public static ArrayOfFrequencyCapSettings parseFrequencyCapSettings(String value)
+    {
+        if (value == null || value.isEmpty()) {
+        	return null;
+        }
+        
+        if (value == StringTable.DeleteValue) {
+        	return new ArrayOfFrequencyCapSettings();
+        }
+        
+        try {
+        	ObjectMapper mapper = new ObjectMapper();
+        	ArrayOfFrequencyCapSettings result = new ArrayOfFrequencyCapSettings();
+        	FrequencyCapSettings[] settings = mapper.readValue(value, FrequencyCapSettings[].class);
+        	for (FrequencyCapSettings setting : settings) {
+        		result.getFrequencyCapSettings().add(setting);
+        	}
+        	return result;
+
+        } catch (IOException e) {
+        	e.printStackTrace();
+        }
+        return null;
     }
     
     public static String toCriterionBidMultiplierBulkString(Double v) {

--- a/src/main/java/com/microsoft/bingads/v13/internal/bulk/StringTable.java
+++ b/src/main/java/com/microsoft/bingads/v13/internal/bulk/StringTable.java
@@ -140,6 +140,7 @@ public class StringTable {
     
     public static final String CpvBid = "Cpv Bid";
     public static final String CpmBid = "Cpm Bid";
+    public static final String FrequencyCapSettings = "Frequency Cap Settings";
 
     // entity types
     public static final String SemanticVersion = "Format Version";

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/adgroup/read/BulkAdgroupReadFromRowValuesFrequencyCapSettingsTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/adgroup/read/BulkAdgroupReadFromRowValuesFrequencyCapSettingsTest.java
@@ -1,0 +1,63 @@
+package com.microsoft.bingads.v13.api.test.entities.adgroup.read;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+
+import com.microsoft.bingads.internal.functionalinterfaces.Function;
+import com.microsoft.bingads.v13.api.test.entities.ObjectComparer;
+import com.microsoft.bingads.v13.api.test.entities.adgroup.BulkAdGroupTest;
+import com.microsoft.bingads.v13.bulk.entities.BulkAdGroup;
+import com.microsoft.bingads.v13.campaignmanagement.ArrayOfFrequencyCapSettings;
+import com.microsoft.bingads.v13.campaignmanagement.FrequencyCapSettings;
+import com.microsoft.bingads.v13.campaignmanagement.FrequencyCapTimeGranularity;
+
+@RunWith(Parameterized.class)
+public class BulkAdgroupReadFromRowValuesFrequencyCapSettingsTest extends BulkAdGroupTest {
+    
+    @Parameter(value = 0)
+    public String datum;
+
+    @Parameterized.Parameter(value = 1)
+    public ArrayOfFrequencyCapSettings expectedResult;
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        ArrayOfFrequencyCapSettings settings = new ArrayOfFrequencyCapSettings();
+        FrequencyCapSettings setting = new FrequencyCapSettings();
+        setting.setCapValue(10);
+        setting.setFrequencyCapUnit("IMPRESSION");
+        setting.setTimeGranularity(FrequencyCapTimeGranularity.HOUR);
+        settings.getFrequencyCapSettings().add(setting);
+        return Arrays.asList(
+                new Object[][]{
+                        {"[{\"capValue\":10,\"frequencyCapUnit\":\"IMPRESSION\",\"timeGranularity\":\"HOUR\"}]", settings},
+                        {"delete_value", new ArrayOfFrequencyCapSettings()}
+                }
+        );
+    }
+
+    @Test
+    public void testRead() {
+        testReadProperty(
+                "Frequency Cap Settings",
+                datum,
+                expectedResult,
+                new Function<BulkAdGroup, ArrayOfFrequencyCapSettings>() {
+                    @Override
+                    public ArrayOfFrequencyCapSettings apply(BulkAdGroup c) {
+                        return c.getAdGroup().getFrequencyCapSettings();
+                    }
+                },
+                new ObjectComparer<ArrayOfFrequencyCapSettings>()
+        );
+    }
+    
+}

--- a/src/test/java/com/microsoft/bingads/v13/api/test/entities/adgroup/write/BulkAdGroupWriteToRowValuesFrequencyCapSettingsTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/entities/adgroup/write/BulkAdGroupWriteToRowValuesFrequencyCapSettingsTest.java
@@ -1,0 +1,50 @@
+package com.microsoft.bingads.v13.api.test.entities.adgroup.write;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.microsoft.bingads.internal.functionalinterfaces.BiConsumer;
+import com.microsoft.bingads.v13.api.test.entities.adgroup.BulkAdGroupTest;
+import com.microsoft.bingads.v13.bulk.entities.BulkAdGroup;
+import com.microsoft.bingads.v13.campaignmanagement.ArrayOfFrequencyCapSettings;
+import com.microsoft.bingads.v13.campaignmanagement.FrequencyCapSettings;
+import com.microsoft.bingads.v13.campaignmanagement.FrequencyCapTimeGranularity;
+
+@RunWith(Parameterized.class)
+public class BulkAdGroupWriteToRowValuesFrequencyCapSettingsTest extends BulkAdGroupTest {
+    
+    @Parameter(value = 1)
+    public ArrayOfFrequencyCapSettings propertyValue;
+
+    @Parameters
+    public static Collection<Object[]> data() {
+    	ArrayOfFrequencyCapSettings settings = new ArrayOfFrequencyCapSettings();
+        FrequencyCapSettings setting = new FrequencyCapSettings();
+        setting.setCapValue(10);
+        setting.setFrequencyCapUnit("IMPRESSION");
+        setting.setTimeGranularity(FrequencyCapTimeGranularity.HOUR);
+        settings.getFrequencyCapSettings().add(setting);
+        return Arrays.asList(new Object[][]{
+        	{"[{\"capValue\":10,\"frequencyCapUnit\":\"IMPRESSION\",\"timeGranularity\":\"HOUR\"}]", settings},
+        	{null, null},
+        	{"delete_value", new ArrayOfFrequencyCapSettings()}
+        });
+    }
+
+    @Test
+    public void testWrite() {
+        this.<ArrayOfFrequencyCapSettings>testWriteProperty("Frequency Cap Settings", this.datum, this.propertyValue, new BiConsumer<BulkAdGroup, ArrayOfFrequencyCapSettings>() {
+            @Override
+            public void accept(BulkAdGroup c, ArrayOfFrequencyCapSettings v) {
+                c.getAdGroup().setFrequencyCapSettings(v);
+            }
+        });
+    }
+    
+}


### PR DESCRIPTION
- Update Bing Ads API Version 13 service proxies to reflect recent interface changes. For details please see the [Bing Ads API Release Notes](https://docs.microsoft.com/en-us/bingads/guides/release-notes).
- Add mappings for new fields in BulkAdgroup: FrequencyCapSettings.