### PR TITLE
Use config of bulk service manager for its operations

### DIFF
--- a/src/main/java/com/microsoft/bingads/v13/bulk/BulkDownloadOperation.java
+++ b/src/main/java/com/microsoft/bingads/v13/bulk/BulkDownloadOperation.java
@@ -4,6 +4,11 @@ import java.util.List;
 
 import com.microsoft.bingads.ApiEnvironment;
 import com.microsoft.bingads.AuthorizationData;
+import com.microsoft.bingads.internal.utilities.HttpClientHttpFileService;
+import com.microsoft.bingads.internal.utilities.HttpFileService;
+import com.microsoft.bingads.internal.utilities.SimpleZipExtractor;
+import com.microsoft.bingads.internal.utilities.ZipExtractor;
+import com.microsoft.bingads.v13.internal.bulk.Config;
 import com.microsoft.bingads.v13.internal.bulk.DownloadStatusProvider;
 
 /**
@@ -32,20 +37,37 @@ public class BulkDownloadOperation extends BulkOperation<DownloadStatus> {
      * @param authorizationData Represents a user who intends to access the
      * corresponding customer and account.     
      */
-    public BulkDownloadOperation(String requestId, AuthorizationData authorizationData) {
-        super(requestId, authorizationData, new DownloadStatusProvider(requestId, authorizationData));
+    public BulkDownloadOperation(String requestId, AuthorizationData authorizationData, int statusPollIntervalInMilliseconds) {
+        this(
+                requestId,
+                authorizationData,
+                null,
+                null,
+                statusPollIntervalInMilliseconds,
+                new HttpClientHttpFileService(),
+                Config.DEFAULT_HTTPCLIENT_TIMEOUT_IN_MS,
+                new SimpleZipExtractor());
     }
 
-    public BulkDownloadOperation(String requestId, AuthorizationData authorizationData, ApiEnvironment apiEnvironment) {
-        super(requestId, authorizationData, new DownloadStatusProvider(requestId, authorizationData), null, apiEnvironment);
-    }
-    
-    BulkDownloadOperation(String requestId, AuthorizationData authorizationData, String trackingId) {
-        super(requestId, authorizationData, new DownloadStatusProvider(requestId, authorizationData), trackingId);
-    }
-    
-    BulkDownloadOperation(String requestId, AuthorizationData authorizationData, String trackingId, ApiEnvironment apiEnvironment) {
-    	super(requestId, authorizationData, new DownloadStatusProvider(requestId, authorizationData), trackingId, apiEnvironment);
+    BulkDownloadOperation(
+            String requestId,
+            AuthorizationData authorizationData,
+            String trackingId,
+            ApiEnvironment apiEnvironment,
+            int statusPollIntervalInMilliseconds,
+            HttpFileService httpFileService,
+            int downloadHttpTimeoutInMilliseconds,
+            ZipExtractor zipExtractor) {
+    	super(
+                requestId,
+                authorizationData,
+                new DownloadStatusProvider(requestId, authorizationData),
+                trackingId,
+                apiEnvironment,
+                statusPollIntervalInMilliseconds,
+                httpFileService,
+                downloadHttpTimeoutInMilliseconds,
+                zipExtractor);
     }
     
     @Override

--- a/src/main/java/com/microsoft/bingads/v13/bulk/BulkDownloadOperation.java
+++ b/src/main/java/com/microsoft/bingads/v13/bulk/BulkDownloadOperation.java
@@ -2,8 +2,7 @@ package com.microsoft.bingads.v13.bulk;
 
 import java.util.List;
 
-import com.microsoft.bingads.ApiEnvironment;
-import com.microsoft.bingads.AuthorizationData;
+import com.microsoft.bingads.ServiceClient;
 import com.microsoft.bingads.internal.utilities.HttpClientHttpFileService;
 import com.microsoft.bingads.internal.utilities.HttpFileService;
 import com.microsoft.bingads.internal.utilities.SimpleZipExtractor;
@@ -34,15 +33,12 @@ public class BulkDownloadOperation extends BulkOperation<DownloadStatus> {
      *
      * @param requestId The identifier of a download request that has previously
      * been submitted.
-     * @param authorizationData Represents a user who intends to access the
-     * corresponding customer and account.     
      */
-    public BulkDownloadOperation(String requestId, AuthorizationData authorizationData, int statusPollIntervalInMilliseconds) {
+    public BulkDownloadOperation(String requestId, ServiceClient<IBulkService> serviceClient, int statusPollIntervalInMilliseconds) {
         this(
                 requestId,
-                authorizationData,
                 null,
-                null,
+                serviceClient,
                 statusPollIntervalInMilliseconds,
                 new HttpClientHttpFileService(),
                 Config.DEFAULT_HTTPCLIENT_TIMEOUT_IN_MS,
@@ -51,23 +47,21 @@ public class BulkDownloadOperation extends BulkOperation<DownloadStatus> {
 
     BulkDownloadOperation(
             String requestId,
-            AuthorizationData authorizationData,
             String trackingId,
-            ApiEnvironment apiEnvironment,
+            ServiceClient<IBulkService> serviceClient,
             int statusPollIntervalInMilliseconds,
             HttpFileService httpFileService,
             int downloadHttpTimeoutInMilliseconds,
             ZipExtractor zipExtractor) {
     	super(
                 requestId,
-                authorizationData,
-                new DownloadStatusProvider(requestId, authorizationData),
                 trackingId,
-                apiEnvironment,
+                serviceClient,
                 statusPollIntervalInMilliseconds,
                 httpFileService,
                 downloadHttpTimeoutInMilliseconds,
-                zipExtractor);
+                zipExtractor,
+                new DownloadStatusProvider(requestId, serviceClient.getAuthorizationData()));
     }
     
     @Override

--- a/src/main/java/com/microsoft/bingads/v13/bulk/BulkOperation.java
+++ b/src/main/java/com/microsoft/bingads/v13/bulk/BulkOperation.java
@@ -29,12 +29,12 @@ public abstract class BulkOperation<TStatus> {
     /**
      * The request identifier corresponding to the bulk upload or download, depending on the derived type.
      */
-    private String requestId;
+    private final String requestId;
 
     /**
      * The identifier of the log entry that contains the details of the upload or download request.
      */
-    private String trackingId;
+    private final String trackingId;
 
     private final ServiceClient<IBulkService> serviceClient;
 
@@ -162,14 +162,6 @@ public abstract class BulkOperation<TStatus> {
         return statusProvider;
     }
 
-    void setRequestId(String requestId) {
-        this.requestId = requestId;
-    }
-
-    void setTrackingId(String trackingId) {
-        this.trackingId = trackingId;
-    }
-
     HttpFileService getHttpFileService() {
         return httpFileService;
     }
@@ -226,7 +218,8 @@ public abstract class BulkOperation<TStatus> {
 
     abstract RuntimeException getOperationCouldNotBeCompletedException(List<OperationError> errors, TStatus status);
 
-    private Future<File> downloadResultFileAsyncImpl(final File localResultDirectoryName, final String localResultFileName, final boolean decompress, final boolean overwrite, AsyncCallback<File> callback) throws IOException, URISyntaxException {
+    private Future<File> downloadResultFileAsyncImpl(final File
+            localResultDirectoryName, final String localResultFileName, final boolean decompress, final boolean overwrite, AsyncCallback<File> callback) throws IOException, URISyntaxException {
         final ResultFuture<File> resultFuture = new ResultFuture<File>(callback);
 
         if (finalStatus == null) {

--- a/src/main/java/com/microsoft/bingads/v13/bulk/BulkServiceManager.java
+++ b/src/main/java/com/microsoft/bingads/v13/bulk/BulkServiceManager.java
@@ -201,9 +201,8 @@ public class BulkServiceManager {
                         if (needToFallBacktoAsync(result)) {
                             BulkUploadOperation operation = new BulkUploadOperation(
                                     result.getRequestId(),
-                                    authorizationData,
                                     ServiceUtils.GetTrackingId(res),
-                                    apiEnvironment,
+                                    serviceClient,
                                     statusPollIntervalInMilliseconds,
                                     httpFileService,
                                     downloadHttpTimeoutInMilliseconds,
@@ -572,9 +571,8 @@ public class BulkServiceManager {
 
                         BulkDownloadOperation operation = new BulkDownloadOperation(
                                 response.getDownloadRequestId(),
-                                authorizationData,
                                 trackingId,
-                                apiEnvironment,
+                                serviceClient,
                                 statusPollIntervalInMilliseconds,
                                 httpFileService,
                                 downloadHttpTimeoutInMilliseconds,
@@ -603,9 +601,8 @@ public class BulkServiceManager {
 
                         BulkDownloadOperation operation = new BulkDownloadOperation(
                                 response.getDownloadRequestId(),
-                                authorizationData,
                                 ServiceUtils.GetTrackingId(res),
-                                apiEnvironment,
+                                serviceClient,
                                 statusPollIntervalInMilliseconds,
                                 httpFileService,
                                 downloadHttpTimeoutInMilliseconds,
@@ -704,9 +701,8 @@ public class BulkServiceManager {
                     }
                     BulkUploadOperation operation = new BulkUploadOperation(
                             response.getRequestId(),
-                            authorizationData,
                             trackingId,
-                            apiEnvironment,
+                            serviceClient,
                             statusPollIntervalInMilliseconds,
                             httpFileService,
                             downloadHttpTimeoutInMilliseconds,

--- a/src/main/java/com/microsoft/bingads/v13/bulk/BulkUploadOperation.java
+++ b/src/main/java/com/microsoft/bingads/v13/bulk/BulkUploadOperation.java
@@ -2,8 +2,7 @@ package com.microsoft.bingads.v13.bulk;
 
 import java.util.List;
 
-import com.microsoft.bingads.ApiEnvironment;
-import com.microsoft.bingads.AuthorizationData;
+import com.microsoft.bingads.ServiceClient;
 import com.microsoft.bingads.internal.utilities.HttpClientHttpFileService;
 import com.microsoft.bingads.internal.utilities.HttpFileService;
 import com.microsoft.bingads.internal.utilities.SimpleZipExtractor;
@@ -30,14 +29,12 @@ public class BulkUploadOperation extends BulkOperation<UploadStatus> {
      * Initializes a new instance of this class with the specified requestId and authorization data.
      *
      * @param requestId The identifier of an upload request that has previously been submitted.
-     * @param authorizationData Represents a user who intends to access the corresponding customer and account.
      */
-	public BulkUploadOperation(String requestId, AuthorizationData authorizationData, int statusPollIntervalInMilliseconds) {
+	public BulkUploadOperation(String requestId, ServiceClient<IBulkService> serviceClient, int statusPollIntervalInMilliseconds) {
         this(
                 requestId,
-                authorizationData,
                 null,
-                null,
+                serviceClient,
                 statusPollIntervalInMilliseconds,
                 new HttpClientHttpFileService(),
                 Config.DEFAULT_HTTPCLIENT_TIMEOUT_IN_MS,
@@ -46,23 +43,21 @@ public class BulkUploadOperation extends BulkOperation<UploadStatus> {
     
     BulkUploadOperation(
             String requestId,
-            AuthorizationData authorizationData,
             String trackingId,
-            ApiEnvironment apiEnvironment,
+            ServiceClient<IBulkService> serviceClient,
             int statusPollIntervalInMilliseconds,
             HttpFileService httpFileService,
             int downloadHttpTimeoutInMilliseconds,
             ZipExtractor zipExtractor) {
         super(
                 requestId,
-                authorizationData,
-                new UploadStatusProvider(requestId),
                 trackingId,
-                apiEnvironment,
+                serviceClient,
                 statusPollIntervalInMilliseconds,
                 httpFileService,
                 downloadHttpTimeoutInMilliseconds,
-                zipExtractor);
+                zipExtractor,
+                new UploadStatusProvider(requestId));
     }
 
     @Override

--- a/src/main/java/com/microsoft/bingads/v13/bulk/BulkUploadOperation.java
+++ b/src/main/java/com/microsoft/bingads/v13/bulk/BulkUploadOperation.java
@@ -4,6 +4,11 @@ import java.util.List;
 
 import com.microsoft.bingads.ApiEnvironment;
 import com.microsoft.bingads.AuthorizationData;
+import com.microsoft.bingads.internal.utilities.HttpClientHttpFileService;
+import com.microsoft.bingads.internal.utilities.HttpFileService;
+import com.microsoft.bingads.internal.utilities.SimpleZipExtractor;
+import com.microsoft.bingads.internal.utilities.ZipExtractor;
+import com.microsoft.bingads.v13.internal.bulk.Config;
 import com.microsoft.bingads.v13.internal.bulk.UploadStatusProvider;
 
 /**
@@ -27,20 +32,37 @@ public class BulkUploadOperation extends BulkOperation<UploadStatus> {
      * @param requestId The identifier of an upload request that has previously been submitted.
      * @param authorizationData Represents a user who intends to access the corresponding customer and account.
      */
-	public BulkUploadOperation(String requestId, AuthorizationData authorizationData, IBulkService service) {
-        this(requestId, authorizationData, service, null, null);
+	public BulkUploadOperation(String requestId, AuthorizationData authorizationData, int statusPollIntervalInMilliseconds) {
+        this(
+                requestId,
+                authorizationData,
+                null,
+                null,
+                statusPollIntervalInMilliseconds,
+                new HttpClientHttpFileService(),
+                Config.DEFAULT_HTTPCLIENT_TIMEOUT_IN_MS,
+                new SimpleZipExtractor());
     }
     
-    public BulkUploadOperation(String requestId, AuthorizationData authorizationData, IBulkService service, ApiEnvironment apiEnvironment) {
-    	this(requestId, authorizationData, service, null, apiEnvironment);
-    }
-
-    protected BulkUploadOperation(String requestId, AuthorizationData authorizationData, IBulkService service, String trackingId) {
-    	this(requestId, authorizationData, service, trackingId, null);
-    }
-    
-    protected BulkUploadOperation(String requestId, AuthorizationData authorizationData, IBulkService service, String trackingId, ApiEnvironment apiEnvironment) {
-        super(requestId, authorizationData, new UploadStatusProvider(requestId), trackingId, apiEnvironment);
+    BulkUploadOperation(
+            String requestId,
+            AuthorizationData authorizationData,
+            String trackingId,
+            ApiEnvironment apiEnvironment,
+            int statusPollIntervalInMilliseconds,
+            HttpFileService httpFileService,
+            int downloadHttpTimeoutInMilliseconds,
+            ZipExtractor zipExtractor) {
+        super(
+                requestId,
+                authorizationData,
+                new UploadStatusProvider(requestId),
+                trackingId,
+                apiEnvironment,
+                statusPollIntervalInMilliseconds,
+                httpFileService,
+                downloadHttpTimeoutInMilliseconds,
+                zipExtractor);
     }
 
     @Override

--- a/src/test/java/com/microsoft/bingads/v13/api/test/operations/bulk_download_operation/BulkDownloadOperationTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/operations/bulk_download_operation/BulkDownloadOperationTest.java
@@ -7,6 +7,7 @@ import com.microsoft.bingads.v13.bulk.ArrayOfKeyValuePairOfstringstring;
 import com.microsoft.bingads.v13.bulk.BulkDownloadOperation;
 import com.microsoft.bingads.v13.bulk.GetBulkDownloadStatusResponse;
 import com.microsoft.bingads.v13.bulk.IBulkService;
+import com.microsoft.bingads.v13.internal.bulk.Config;
 
 public class BulkDownloadOperationTest extends FakeApiTest {
 
@@ -23,13 +24,8 @@ public class BulkDownloadOperationTest extends FakeApiTest {
     }
 
     protected BulkDownloadOperation createBulkDownloadOperation(Integer statusCheckIntervalInMs) {
-        BulkDownloadOperation operation = new BulkDownloadOperation("request123", createUserData());
-
-        if (statusCheckIntervalInMs != null) {
-            operation.setStatusPollIntervalInMilliseconds(statusCheckIntervalInMs);
-        }
-
-        return operation;
+        return new BulkDownloadOperation("request123", createUserData(),
+                statusCheckIntervalInMs != null ? statusCheckIntervalInMs : Config.DEFAULT_STATUS_CHECK_INTERVAL_IN_MS);
     }
 
     protected GetBulkDownloadStatusResponse createStatusResponse(Integer percentComplete, String status, String resultFileUrl) {

--- a/src/test/java/com/microsoft/bingads/v13/api/test/operations/bulk_download_operation/BulkDownloadOperationTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/operations/bulk_download_operation/BulkDownloadOperationTest.java
@@ -2,6 +2,7 @@ package com.microsoft.bingads.v13.api.test.operations.bulk_download_operation;
 
 import com.microsoft.bingads.AuthorizationData;
 import com.microsoft.bingads.PasswordAuthentication;
+import com.microsoft.bingads.ServiceClient;
 import com.microsoft.bingads.v13.api.test.operations.FakeApiTest;
 import com.microsoft.bingads.v13.bulk.ArrayOfKeyValuePairOfstringstring;
 import com.microsoft.bingads.v13.bulk.BulkDownloadOperation;
@@ -24,7 +25,9 @@ public class BulkDownloadOperationTest extends FakeApiTest {
     }
 
     protected BulkDownloadOperation createBulkDownloadOperation(Integer statusCheckIntervalInMs) {
-        return new BulkDownloadOperation("request123", createUserData(),
+        return new BulkDownloadOperation(
+                "request123",
+                new ServiceClient<>(createUserData(), IBulkService.class),
                 statusCheckIntervalInMs != null ? statusCheckIntervalInMs : Config.DEFAULT_STATUS_CHECK_INTERVAL_IN_MS);
     }
 

--- a/src/test/java/com/microsoft/bingads/v13/api/test/operations/bulk_upload_operation/BulkUploadOperationTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/operations/bulk_upload_operation/BulkUploadOperationTest.java
@@ -8,6 +8,7 @@ import com.microsoft.bingads.v13.bulk.ArrayOfKeyValuePairOfstringstring;
 import com.microsoft.bingads.v13.bulk.BulkUploadOperation;
 import com.microsoft.bingads.v13.bulk.GetBulkUploadStatusResponse;
 import com.microsoft.bingads.v13.bulk.IBulkService;
+import com.microsoft.bingads.v13.internal.bulk.Config;
 
 public class BulkUploadOperationTest extends FakeApiTest {
 
@@ -24,13 +25,8 @@ public class BulkUploadOperationTest extends FakeApiTest {
     }
 
     protected BulkUploadOperation createBulkUploadOperation(Integer statusCheckIntervalInMs) {
-        BulkUploadOperation operation = new BulkUploadOperation("request123", createUserData(), service);
-
-        if (statusCheckIntervalInMs != null) {
-            operation.setStatusPollIntervalInMilliseconds(statusCheckIntervalInMs);
-        }
-
-        return operation;
+        return new BulkUploadOperation("request123", createUserData(),
+                statusCheckIntervalInMs != null ? statusCheckIntervalInMs : Config.DEFAULT_STATUS_CHECK_INTERVAL_IN_MS);
     }
 
     protected GetBulkUploadStatusResponse createStatusResponse(Integer percentComplete, String status, String resultFileUrl) {

--- a/src/test/java/com/microsoft/bingads/v13/api/test/operations/bulk_upload_operation/BulkUploadOperationTest.java
+++ b/src/test/java/com/microsoft/bingads/v13/api/test/operations/bulk_upload_operation/BulkUploadOperationTest.java
@@ -3,6 +3,7 @@ package com.microsoft.bingads.v13.api.test.operations.bulk_upload_operation;
 
 import com.microsoft.bingads.AuthorizationData;
 import com.microsoft.bingads.PasswordAuthentication;
+import com.microsoft.bingads.ServiceClient;
 import com.microsoft.bingads.v13.api.test.operations.FakeApiTest;
 import com.microsoft.bingads.v13.bulk.ArrayOfKeyValuePairOfstringstring;
 import com.microsoft.bingads.v13.bulk.BulkUploadOperation;
@@ -25,7 +26,9 @@ public class BulkUploadOperationTest extends FakeApiTest {
     }
 
     protected BulkUploadOperation createBulkUploadOperation(Integer statusCheckIntervalInMs) {
-        return new BulkUploadOperation("request123", createUserData(),
+        return new BulkUploadOperation(
+                "request123",
+                new ServiceClient<>(createUserData(), IBulkService.class),
                 statusCheckIntervalInMs != null ? statusCheckIntervalInMs : Config.DEFAULT_STATUS_CHECK_INTERVAL_IN_MS);
     }
 


### PR DESCRIPTION
The bulk service manager can be configure in various ways. Some of them (e.g. the http file service) won't always be passed to the operations. This PR changes that.

## Use case: 
We are using NAT. Thus creating and closing HTTP connection to the same destination in a very fast pace leads to resource problems. This MR allows to use one http file service for all operations of the bulk service manager to allow for using one connection pool.