### PR TITLE
Route CI Maven resolution through Azure Artifacts + onboard to CFSClean (SFI-ES4.2.4)

### DIFF
--- a/.pipelines/settings.xml
+++ b/.pipelines/settings.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  CI-ONLY Maven settings.
+
+  This file is consumed exclusively by azure-pipelines.yml, which copies it to
+  ~/.m2/settings.xml on the build agent before invoking Maven. It is NOT used by,
+  and has no effect on, developers building this SDK locally or consumers pulling
+  com.microsoft.bingads:microsoft.bingads from Maven Central.
+
+  Purpose: Microsoft's internal build compliance policy (SFI-ES4.2.4) forbids build
+  pipelines from reaching public package endpoints such as repo.maven.apache.org.
+  The mirror below redirects all artifact and plugin resolution through an Azure
+  Artifacts feed, which proxies Maven Central upstream.
+
+  The mirror <id> must match the feed name passed to the MavenAuthenticate@0 task
+  in the pipeline, so that task injects credentials for this mirror.
+
+  The equivalent override is deliberately NOT placed in pom.xml: this is a public
+  repository, and <repositories> entries in a released POM are inherited by
+  downstream consumers and are rejected by Maven Central's publishing requirements.
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <mirrors>
+    <mirror>
+      <id>bing_ads_PublicPackages</id>
+      <name>Azure Artifacts mirror of Maven Central</name>
+      <url>https://pkgs.dev.azure.com/msasg/bing_ads/_packaging/bing_ads_PublicPackages/maven/v1</url>
+      <mirrorOf>*</mirrorOf>
+    </mirror>
+  </mirrors>
+</settings>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,6 +35,24 @@ extends:
               gpg --import public.key
               gpg --batch --import private.key
               gpg --list-public-keys
+        # SFI-ES4.2.4: route all Maven artifact and plugin resolution through Azure
+        # Artifacts instead of public endpoints (repo.maven.apache.org et al).
+        # This must run BEFORE MavenAuthenticate@0, which edits ~/.m2/settings.xml
+        # in place to add credentials for the mirror declared here.
+        - task: PowerShell@2
+          displayName: 'Install CI Maven settings.xml'
+          inputs:
+            targetType: inline
+            script: |
+              $m2 = Join-Path $env:USERPROFILE '.m2'
+              New-Item -ItemType Directory -Force -Path $m2 | Out-Null
+              Copy-Item -LiteralPath '$(Build.SourcesDirectory)\.pipelines\settings.xml' `
+                        -Destination (Join-Path $m2 'settings.xml') -Force
+              Write-Host "Installed settings.xml to $m2"
+        - task: MavenAuthenticate@0
+          displayName: 'Authenticate Maven to Azure Artifacts'
+          inputs:
+            artifactsFeeds: bing_ads_PublicPackages
         - task: Maven@3
           inputs:
             mavenPomFile: 'pom.xml'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,6 +18,13 @@ resources:
 extends:
   template: v1/WebXT.Official.EntryPoint.yml@WebXT.Pipeline.Templates
   parameters:
+    settings:
+      # SFI-ES4.2.4 / MountainPass network isolation. Permissive is the enforced
+      # policy; the CFSClean* policies run alongside it in audit mode and report
+      # any connection to a public package endpoint in the "Stop Network Isolation"
+      # step. The list replaces the defaults rather than appending to them, so all
+      # required policies must be named here.
+      networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3
     pool:
       name: Azure-Pipelines-1ESPT-ExDShared
       image: windows-latest


### PR DESCRIPTION
## Why

Use internal feeds to avoid SFI flag
## What changed

**`.pipelines/settings.xml`** (new, CI-only)
- Declares a Maven `<mirror>` with `mirrorOf: *` pointing at the `bing_ads_PublicPackages` Azure Artifacts feed (the org's Maven Central proxy).
- Consumed only by the pipeline — copied to `~/.m2/settings.xml` on the agent. Has zero effect on local developer builds or on consumers pulling from Maven Central.

**`azure-pipelines.yml`**
- Adds a step to install the CI `settings.xml`, followed by `MavenAuthenticate@0` (`artifactsFeeds: bing_ads_PublicPackages`). The copy runs first because `MavenAuthenticate` rewrites the settings file in place; the mirror `<id>` matches the feed name so credentials attach to the mirror.
- Sets `settings.networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3` to onboard the pipeline to network isolation. `Permissive` stays enforced; the `CFSClean*` policies audit and report any public-endpoint connection.

## Why not override `central` in pom.xml

This is a public repo that publishes to Maven Central via OSSRH. `<repositories>` entries in a released POM are inherited by downstream consumers and are rejected by Central's publishing requirements, and an internal feed URL would break external clone-and-build. The `settings.xml` mirror is the approach the SFI guidance sanctions for this case, and leaves `pom.xml` untouched.

## Validation

- `settings.xml` parses as valid XML; `azure-pipelines.yml` parses as valid YAML with the expected step order (`CmdLine → install settings → MavenAuthenticate → Maven → CopyFiles`).


/cc @yuzehe1